### PR TITLE
课表页面的 Flatlist 换用 paging 属性

### DIFF
--- a/apps/thu-info-app/src/ui/schedule/schedule.tsx
+++ b/apps/thu-info-app/src/ui/schedule/schedule.tsx
@@ -545,8 +545,7 @@ export const ScheduleScreen = ({navigation}: {navigation: RootNav}) => {
 									);
 									setWeekRef && setWeekRef(index + 1);
 								}}
-								snapToInterval={scheduleBodyWidth}
-								decelerationRate="fast"
+								pagingEnabled={true}
 							/>
 						</View>
 					</View>


### PR DESCRIPTION
优点：一次只翻一页，在 UI 上比较连贯，不像之前停下来的时候有明显的卡顿。可能有助于解决向右滑的问题。

缺点：一次只能翻一页。。。