### PR TITLE
feat: let navbar's background transparent

### DIFF
--- a/apps/thu-info-app/android/app/src/main/java/com/unidy2002/thuinfo/MainActivity.kt
+++ b/apps/thu-info-app/android/app/src/main/java/com/unidy2002/thuinfo/MainActivity.kt
@@ -1,6 +1,9 @@
 package com.unidy2002.thuinfo
 
 import android.os.Bundle
+import android.os.Build
+import android.graphics.Color
+import android.view.View
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -15,6 +18,14 @@ class MainActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(null)
+        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+        and (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM)) {
+            window.setNavigationBarContrastEnforced(false)
+            window.setNavigationBarColor(Color.TRANSPARENT)
+            window.getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                )
+        }
     }
 
     /**


### PR DESCRIPTION
**What is the purpose of this PR?**

- [ ] Fixing a bug
- [x] Adding a feature

**Is there a related issue?**

no

- [x] I understand that *adding a new feature* before *creating a feature request issue* has a high chance of rejection.

**Please describe your changes.**

Let navbar's background be transparent to make it more immersive

**Are there any possible drawbacks or side-effects?**

It should work on API 26 to 29 without warning, and works on API 30 to 34 with deprecation warning. On and after 35, Google force apps to be immersive

**How to verify the changes?**

Check the background color of navigation bar on Android.