### PR TITLE
fix(deepseek): fix legacy empty chat

### DIFF
--- a/apps/thu-info-app/src/ui/home/deepseek.tsx
+++ b/apps/thu-info-app/src/ui/home/deepseek.tsx
@@ -379,7 +379,13 @@ export const DeepSeekScreen = ({route: {params}}: {route: DeepSeekTabProp}) => {
 			history.length === 0 ||
 			Date.now() - (history[0].timestamp ?? 0) > 1000 * 60 * 30
 		) {
-			dispatch(deepseekUpdateHistory(newConversation()));
+			if (history.length > 0 && history[0]?.messages.length === 0 && history[0]?.title === getStr("newConversation")) {
+				const newConv = newConversation();
+				newConv.id = history[0].id;
+				dispatch(deepseekUpdateHistory(newConv));
+			} else {
+				dispatch(deepseekUpdateHistory(newConversation()));
+			}
 		}
 		setCurrentIndex(0);
 	}, [history, dispatch]);


### PR DESCRIPTION
**What is the purpose of this PR?**

- [x] Fixing a bug
- [ ] Adding a feature

**Is there a related issue?**

legacy empty chat stay in chat history

**Please describe your changes.**

remove legacy empty chat when creating new chat

**Are there any possible drawbacks or side-effects?**

no

**How to verify the changes?**

no legacy empty chat when switch to deepseek tab