### PR TITLE
fix: display correct idle status instead of error

### DIFF
--- a/apps/thu-info-app/src/assets/translations/en.ts
+++ b/apps/thu-info-app/src/assets/translations/en.ts
@@ -665,9 +665,6 @@ export default {
 	washerError: "Error",
 	washerCredit:
 		"Special thanks to gtxzsxxk@github.com for the inspiration of the current UI.",
-	washerNoticeTitle: "Notice",
-	washerNotice:
-		"Service provider has stopped maintaining status for new washers, so any feedback about missing washing machines will not be accepted. Data in this page comes solely from \"华清捷利\" mini program, thus any feedback about extending the page's functionality will not be accepted.",
 	noMoreData: "No more data",
 	hideWeekend: "Hide Weekend",
 	loadAllData: "Load all data",

--- a/apps/thu-info-app/src/assets/translations/zh.ts
+++ b/apps/thu-info-app/src/assets/translations/zh.ts
@@ -631,9 +631,6 @@ export default {
 	minutesAbbr: "分钟",
 	washerError: "故障",
 	washerCredit: "感谢 gtxzsxxk@github.com 同学提供的 UI 灵感",
-	washerNoticeTitle: "重要公告",
-	washerNotice:
-		"厂家已停止对新洗衣机的维护，因此我们不接受对缺少洗衣机的反馈。此外，本系统数据完全来源于“华清捷利”小程序，因此我们不接受有关扩展功能的反馈。",
 	noMoreData: "没有更多数据了~",
 	hideWeekend: "隐藏周末",
 	loadAllData: "加载全部",

--- a/apps/thu-info-app/src/ui/home/washer.tsx
+++ b/apps/thu-info-app/src/ui/home/washer.tsx
@@ -246,47 +246,6 @@ export const WasherScreen = ({ navigation }: { navigation: RootNav }) => {
 		</View>
 	);
 
-	const renderNotice = () => (
-		<View style={{ flexDirection: "column", marginBottom: 32 }}>
-			<View style={{ flexDirection: "row", marginHorizontal: 16 }}>
-				<View
-					style={{
-						flex: 1,
-						height: 1,
-						backgroundColor: theme.colors.primaryLight,
-						alignSelf: "center",
-					}}
-				/>
-				<Text
-					style={{
-						color: theme.colors.primary,
-						fontSize: 20,
-						margin: 16,
-					}}>
-					{getStr("washerNoticeTitle")}
-				</Text>
-				<View
-					style={{
-						flex: 1,
-						height: 1,
-						backgroundColor: theme.colors.primaryLight,
-						alignSelf: "center",
-					}}
-				/>
-			</View>
-			<View style={{ marginHorizontal: 24 }}>
-				<Text
-					style={{
-						color: theme.colors.text,
-						fontWeight: "bold",
-						fontSize: 16,
-					}}>
-					{getStr("washerNotice")}
-				</Text>
-			</View>
-		</View>
-	);
-
 	const renderCredit = () => (
 		<View style={{ marginHorizontal: 24, marginBottom: 32 }}>
 			<Text
@@ -302,7 +261,6 @@ export const WasherScreen = ({ navigation }: { navigation: RootNav }) => {
 	return (
 		<View style={{ backgroundColor: theme.colors.themeBackground, flex: 1 }}>
 			<FlatList
-				ListHeaderComponent={renderNotice()}
 				ListFooterComponent={renderCredit()}
 				data={buildingGroups}
 				renderItem={({ item }) => renderBuildingGroup(item.name, item.buildings)}


### PR DESCRIPTION
:tada: Thanks for taking time to contribute! :tada:

Before we move on, fill out the template so that we can better understand your contribution.

**What is the purpose of this PR?**

- [x] Fixing a bug
- [ ] Adding a feature

**Is there a related issue?**

Fixes #769 

- [x] I understand that *adding a new feature* before *creating a feature request issue* has a high chance of rejection.

**Please describe your changes.**

<!--If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.-->

In washer.tsx, set the default status to "error". Then split the status string obtained from the API call by spaces, and modify the status only when keywords such as "待机", "工作", or "运转" are detected.

将默认状态设置为 error。然后按空格分割调用 API 得到的状态字符串，检测到“待机”“工作”“运转”等关键词再修改状态。

**Are there any possible drawbacks or side-effects?**

<!--It is okay if the changes you made do not have drawbacks, but in case they do, please let us know.-->

鉴于这个 API 返回非常混沌无法完全测试，可能存在一些无法处理的情况。

Given that the API responses cannot be fully tested, there might be some cases that cannot be handled.

**How to verify the changes?**

After testing on the emulator it works.

我测过了是对的.jpg

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
