### PR TITLE
fix: restore Android keyboard avoidance and cover input screens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,10 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/sanchuanhehe/harmony-next-pipeline-docker/harmonyos-ci-image:latest
     steps:
-      # setup-harmony.sh applies a reverse patch from commit 09ff3a86; shallow clones lack that object.
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
       - name: Setup caching
         if: startsWith(github.ref, 'refs/tags') == false
         uses: actions/cache@v6

--- a/apps/thu-info-app/.jestsetup.js
+++ b/apps/thu-info-app/.jestsetup.js
@@ -8,7 +8,10 @@ import mockClipboard from '@react-native-clipboard/clipboard/jest/clipboard-mock
 
 jest.mock('@react-native-clipboard/clipboard', () => mockClipboard);
 jest.mock('react-native-device-info', () => mockRNDeviceInfo)
-jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter', () => ({
+	__esModule: true,
+	default: require('react-native/Libraries/vendor/emitter/EventEmitter').default,
+}));
 
 jest.mock("react-native-localize", () => ({
 	findBestAvailableLanguage: () => ({

--- a/apps/thu-info-app/src/components/keyboardAvoidingScreen.tsx
+++ b/apps/thu-info-app/src/components/keyboardAvoidingScreen.tsx
@@ -1,0 +1,26 @@
+import {useContext} from "react";
+import {HeaderHeightContext} from "@react-navigation/elements";
+import {KeyboardAvoidingView, Platform, View, ViewProps} from "react-native";
+
+type Props = ViewProps & {keyboardVerticalOffset?: number};
+
+// Keep absolute-positioned children inside the area left above the keyboard.
+// The PIN unlock screen can also render outside a navigation container.
+export const KeyboardAvoidingScreen = ({
+	children,
+	style,
+	keyboardVerticalOffset,
+	...props
+}: Props) => {
+	const headerHeight = useContext(HeaderHeightContext) ?? 0;
+	return (
+		<KeyboardAvoidingView
+			style={{flex: 1}}
+			behavior={Platform.OS === "ios" ? "padding" : "height"}
+			keyboardVerticalOffset={keyboardVerticalOffset ?? headerHeight}>
+			<View {...props} style={[{flex: 1}, style]}>
+				{children}
+			</View>
+		</KeyboardAvoidingView>
+	);
+};

--- a/apps/thu-info-app/src/components/schedule/scheduleAdd.tsx
+++ b/apps/thu-info-app/src/components/schedule/scheduleAdd.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../keyboardAvoidingScreen";
 import {useEffect, useState} from "react";
 import {
 	Alert,
@@ -816,7 +817,9 @@ export const ScheduleAddModal = ({
 			animationType="fade"
 			onRequestClose={onClose}
 			transparent={true}>
-			<View style={{flex: 1, justifyContent: "flex-start"}}>
+			<KeyboardAvoidingScreen
+				keyboardVerticalOffset={0}
+				style={{flex: 1, justifyContent: "flex-start"}}>
 				<TouchableOpacity
 					activeOpacity={1}
 					onPress={onClose}
@@ -839,6 +842,7 @@ export const ScheduleAddModal = ({
 						borderRadius: 12,
 						backgroundColor: modalBackgroundColor,
 						maxHeight: modalCardMaxHeight,
+						flexShrink: 1,
 						overflow: "hidden",
 					}}>
 					<View
@@ -1633,7 +1637,7 @@ export const ScheduleAddModal = ({
 						)}
 					</ScrollView>
 				</TouchableOpacity>
-			</View>
+			</KeyboardAvoidingScreen>
 		</Modal>
 	);
 };

--- a/apps/thu-info-app/src/components/settings/paginatedRefreshListScreen.tsx
+++ b/apps/thu-info-app/src/components/settings/paginatedRefreshListScreen.tsx
@@ -1,5 +1,5 @@
 import {ThemedRefreshControl} from "../themedRefreshControl";
-import {FC, PropsWithChildren, ReactElement, useEffect, useState} from "react";
+import {PropsWithChildren, ReactElement, useEffect, useState} from "react";
 import {Snackbar} from "react-native-snackbar";
 import {getStr} from "../../utils/i18n";
 import {FlatList, StyleProp, ViewStyle} from "react-native";
@@ -22,7 +22,7 @@ export function paginatedRefreshListScreen<T, R>(
 	empty?: (theme: Theme) => ReactElement,
 	initialNumToRender?: number,
 	containerStyles?: StyleProp<ViewStyle>,
-): FC<PropsWithChildren<R>> {
+): (props: PropsWithChildren<R>) => ReactElement {
 	return (props: PropsWithChildren<R>) => {
 		const [data, setData] = useState<T[]>([]);
 		const [page, setPage] = useState<number>(1);

--- a/apps/thu-info-app/src/components/views.tsx
+++ b/apps/thu-info-app/src/components/views.tsx
@@ -1,5 +1,6 @@
 import {ThemedRefreshControl} from "./themedRefreshControl";
 import {createElement, ReactElement, useCallback, useEffect, useRef, useState} from "react";
+import {KeyboardAvoidingScreen} from "./keyboardAvoidingScreen";
 import {
 	Animated,
 	BackHandler,
@@ -394,7 +395,8 @@ export const BottomPopupTriggerView = (props: TouchableOpacityProps & PopupProps
 		<>
 			<TouchableOpacity {...triggerProps} />
 			<Modal visible={visible} transparent onRequestClose={handleSystemClose}>
-				<Animated.View
+				<KeyboardAvoidingScreen
+					keyboardVerticalOffset={0}
 					style={{
 						width: "100%",
 						height: "100%",
@@ -488,7 +490,7 @@ export const BottomPopupTriggerView = (props: TouchableOpacityProps & PopupProps
 							? props.popupContent(() => animateCloseWith("backdrop", props.popupOnCancelled))
 							: props.popupContent}
 					</Animated.View>
-				</Animated.View>
+				</KeyboardAvoidingScreen>
 			</Modal>
 		</>
 	);

--- a/apps/thu-info-app/src/redux/serializable.ts
+++ b/apps/thu-info-app/src/redux/serializable.ts
@@ -1,0 +1,14 @@
+import {isPlain} from "@reduxjs/toolkit";
+import dayjs from "dayjs";
+
+// Schedule times are kept as Dayjs instances at runtime because the schedule
+// UI and reducers use Dayjs methods. They are converted to timestamps by
+// scheduleTransform before persistence, so treat them as an accepted atomic
+// value in RTK's serializability check.
+export const isSerializable = (value: unknown) =>
+	dayjs.isDayjs(value) || isPlain(value);
+
+export const getSerializableEntries = (value: unknown): [string, unknown][] =>
+	dayjs.isDayjs(value)
+		? []
+		: Object.entries(value as Record<string, unknown>);

--- a/apps/thu-info-app/src/redux/store.ts
+++ b/apps/thu-info-app/src/redux/store.ts
@@ -52,6 +52,7 @@ import {
 import { LoginError } from "@thu-info/lib/src/utils/error";
 import DeviceInfo from "react-native-device-info";
 import { deepseekReducer, DeepseekState, defaultDeepseek } from "./slices/deepseek.ts";
+import {getSerializableEntries, isSerializable} from "./serializable";
 
 const CookieManager = (() => {
 	try {
@@ -319,6 +320,8 @@ export const store = configureStore({
 		getDefaultMiddleware({
 			serializableCheck: {
 				ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+				isSerializable,
+				getEntries: getSerializableEntries,
 			},
 		}),
 });

--- a/apps/thu-info-app/src/ui/home/crCoursePlan.tsx
+++ b/apps/thu-info-app/src/ui/home/crCoursePlan.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {ThemedRefreshControl} from "../../components/themedRefreshControl";
 import {
 	FlatList,
@@ -41,75 +42,77 @@ export const CrCoursePlanScreen = ({
 	useEffect(refresh, [route.params.semesterId]);
 
 	return (
-		<FlatList
-			style={{flex: 1}}
-			data={coursePlan}
-			ListHeaderComponent={
-				<View style={{flexDirection: "row"}}>
-					<TextInput
-						value={searchKey}
-						onChangeText={setSearchKey}
-						style={{
-							flex: 3,
-							marginLeft: 12,
-							textAlignVertical: "center",
-							fontSize: 15,
-							paddingHorizontal: 12,
-							backgroundColor: colors.themeBackground,
-							color: colors.text,
-							borderColor: colors.inputBorder,
-							borderWidth: 1,
-							borderRadius: 5,
-						}}
-						placeholder={getStr("searchCourseName")}
-						placeholderTextColor={colors.fontB3}
+		<KeyboardAvoidingScreen>
+			<FlatList
+				style={{flex: 1}}
+				data={coursePlan}
+				ListHeaderComponent={
+					<View style={{flexDirection: "row"}}>
+						<TextInput
+							value={searchKey}
+							onChangeText={setSearchKey}
+							style={{
+								flex: 3,
+								marginLeft: 12,
+								textAlignVertical: "center",
+								fontSize: 15,
+								paddingHorizontal: 12,
+								backgroundColor: colors.themeBackground,
+								color: colors.text,
+								borderColor: colors.inputBorder,
+								borderWidth: 1,
+								borderRadius: 5,
+							}}
+							placeholder={getStr("searchCourseName")}
+							placeholderTextColor={colors.fontB3}
+						/>
+						<SettingsLargeButton
+							text={getStr("search")}
+							onPress={() => {
+								navigation.navigate("CrSearchResult", {
+									searchParams: {
+										semester: route.params.semesterId,
+										name: searchKey,
+									},
+								});
+							}}
+							disabled={searchKey.length === 0}
+							redText={false}
+						/>
+					</View>
+				}
+				refreshControl={
+					<ThemedRefreshControl
+						refreshing={refreshing}
+						onRefresh={refresh}
 					/>
-					<SettingsLargeButton
-						text={getStr("search")}
+				}
+				renderItem={({item: {id, name, property, credit, group}}) => (
+					<TouchableOpacity
+						style={{
+							paddingHorizontal: 15,
+							paddingVertical: 6,
+							flexDirection: "row",
+							justifyContent: "space-between",
+						}}
 						onPress={() => {
 							navigation.navigate("CrSearchResult", {
-								searchParams: {
-									semester: route.params.semesterId,
-									name: searchKey,
-								},
+								searchParams: {semester: route.params.semesterId, id},
 							});
-						}}
-						disabled={searchKey.length === 0}
-						redText={false}
-					/>
-				</View>
-			}
-			refreshControl={
-				<ThemedRefreshControl
-					refreshing={refreshing}
-					onRefresh={refresh}
-				/>
-			}
-			renderItem={({item: {id, name, property, credit, group}}) => (
-				<TouchableOpacity
-					style={{
-						paddingHorizontal: 15,
-						paddingVertical: 6,
-						flexDirection: "row",
-						justifyContent: "space-between",
-					}}
-					onPress={() => {
-						navigation.navigate("CrSearchResult", {
-							searchParams: {semester: route.params.semesterId, id},
-						});
-					}}>
-					<View style={{flex: 2, alignItems: "flex-start"}}>
-						<Text style={{fontSize: 16, marginVertical: 2, color: colors.text}}>
-							[{property}] {name}
-						</Text>
-						<Text style={{color: "grey", marginVertical: 2}}>
-							{id} ({credit} cr)
-						</Text>
-						<Text style={{color: "grey", marginVertical: 2}}>{group}</Text>
-					</View>
-				</TouchableOpacity>
-			)}
-			keyExtractor={({id}) => id}
-		/>
+						}}>
+						<View style={{flex: 2, alignItems: "flex-start"}}>
+							<Text style={{fontSize: 16, marginVertical: 2, color: colors.text}}>
+								[{property}] {name}
+							</Text>
+							<Text style={{color: "grey", marginVertical: 2}}>
+								{id} ({credit} cr)
+							</Text>
+							<Text style={{color: "grey", marginVertical: 2}}>{group}</Text>
+						</View>
+					</TouchableOpacity>
+				)}
+				keyExtractor={({id}) => id}
+			/>
+		</KeyboardAvoidingScreen>
 	);
 };

--- a/apps/thu-info-app/src/ui/home/deepseek.tsx
+++ b/apps/thu-info-app/src/ui/home/deepseek.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {
 	FlatList,
 	Modal,
@@ -1281,186 +1282,188 @@ export const DeepSeekScreen = ({route: {params}}: {route: DeepSeekTabProp}) => {
 				</TouchableOpacity>
 			</View>
 			<Modal visible={sidebarOpen} transparent>
-				<Pressable
-					style={{
-						position: "absolute",
-						end: 0,
-						top: 0,
-						width: "100%",
-						height: "100%",
-					}}
-					onPress={() => toggleSidebar(false)}>
-					<Animated.View
+				<KeyboardAvoidingScreen keyboardVerticalOffset={0}>
+					<Pressable
 						style={{
-							flex: 1,
-							opacity: sidebarPosition.interpolate({
-								inputRange: [-1, 0],
-								outputRange: [0, 0.75],
-							}),
-							backgroundColor: colors.themeBackground,
+							position: "absolute",
+							end: 0,
+							top: 0,
+							width: "100%",
+							height: "100%",
 						}}
-					/>
-				</Pressable>
-				<Animated.View
-					style={{
-						position: "absolute",
-						top: 0,
-						transform: [
-							{
-								translateX: sidebarPosition.interpolate({
-									inputRange: [-1, 0],
-									outputRange: [-0.62 * useWindowDimensions().width, 0],
-								}),
-							},
-						],
-						backgroundColor: colors.contentBackground,
-						paddingHorizontal: 16,
-						paddingTop: getStatusBarHeight(true) + 2,
-						paddingBottom: insets.bottom,
-						width: "62%",
-						height: "100%",
-					}}>
-					<View
-						style={{
-							flex: 0,
-							flexDirection: "row",
-							alignItems: "center",
-						}}>
-						<TextInput
-							value={searchKey}
-							onChangeText={setSearchKey}
+						onPress={() => toggleSidebar(false)}>
+						<Animated.View
 							style={{
 								flex: 1,
-								textAlignVertical: "center",
-								fontSize: 14,
-								marginVertical: 4,
-								paddingVertical: 4,
-								paddingHorizontal: 12,
+								opacity: sidebarPosition.interpolate({
+									inputRange: [-1, 0],
+									outputRange: [0, 0.75],
+								}),
 								backgroundColor: colors.themeBackground,
-								color: colors.text,
-								borderColor: colors.themePurple,
-								borderWidth: 1.5,
-								borderRadius: 18,
 							}}
-							placeholder={getStr("search")}
-							placeholderTextColor={colors.fontB3}
 						/>
-					</View>
-					<Text style={{color: colors.fontB2, margin: 4, marginTop: 8}}>
-						{getStr("deepseekLocalStorageNotice")}
-					</Text>
-					<SectionList
-						style={{flex: 1, marginTop: 8}}
-						sections={Object.entries(
-							history.reduce(
-								(acc, item) => {
-									const date = new Date(
-										item.timestamp ?? 0,
-									).toLocaleDateString();
-									if (!acc[date]) {
-										acc[date] = [];
-									}
-									acc[date].push(item);
-									return acc;
+					</Pressable>
+					<Animated.View
+						style={{
+							position: "absolute",
+							top: 0,
+							transform: [
+								{
+									translateX: sidebarPosition.interpolate({
+										inputRange: [-1, 0],
+										outputRange: [-0.62 * useWindowDimensions().width, 0],
+									}),
 								},
-								{} as Record<string, Conversation[]>,
-							),
-						)
-							.sort(
-								([dateA], [dateB]) =>
-									new Date(dateB).getTime() - new Date(dateA).getTime(),
-							)
-							.map(([date, data]) => ({
-								title: date,
-								data,
-							}))}
-						renderItem={({item}) => (
-							<Pressable
+							],
+							backgroundColor: colors.contentBackground,
+							paddingHorizontal: 16,
+							paddingTop: getStatusBarHeight(true) + 2,
+							paddingBottom: insets.bottom,
+							width: "62%",
+							height: "100%",
+						}}>
+						<View
+							style={{
+								flex: 0,
+								flexDirection: "row",
+								alignItems: "center",
+							}}>
+							<TextInput
+								value={searchKey}
+								onChangeText={setSearchKey}
 								style={{
-									padding: 8,
-									marginStart: 4,
-									backgroundColor:
-										deleteId === item.id
-											? colors.statusWarningOpacity
-											: item.timestamp === conversation.timestamp
-												? colors.themeTransparentGrey
-												: colors.contentBackground,
-									borderRadius: 8,
-								}}
-								onPress={() => {
-									setCurrentIndex(history.findIndex((c) => c.id === item.id));
-									toggleSidebar(false);
-								}}
-								onLongPress={() => {
-									setDeleteId(item.id);
-									Alert.alert(
-										getStr("delete"),
-										getStr("deleteConversationConfirm"),
-										[
-											{
-												text: getStr("cancel"),
-												style: "cancel",
-												onPress: () => {
-													setDeleteId(null);
-												},
-											},
-											{
-												text: getStr("confirm"),
-												onPress: () => {
-													dispatch(deepseekDeleteConversation(item));
-													setDeleteId(null);
-													toggleSidebar(false);
-												},
-											},
-										],
-										{
-											cancelable: true,
-											onDismiss: () => {
-												setDeleteId(null);
-											},
-										},
-									);
-								}}>
-								<Text style={{color: colors.text}}>{item.title}</Text>
-							</Pressable>
-						)}
-						renderSectionHeader={({section: {title}}) => (
-							<Text
-								style={{
-									color: colors.fontB2,
-									backgroundColor: colors.contentBackground,
+									flex: 1,
+									textAlignVertical: "center",
+									fontSize: 14,
+									marginVertical: 4,
 									paddingVertical: 4,
-								}}>
-								{title}
+									paddingHorizontal: 12,
+									backgroundColor: colors.themeBackground,
+									color: colors.text,
+									borderColor: colors.themePurple,
+									borderWidth: 1.5,
+									borderRadius: 18,
+								}}
+								placeholder={getStr("search")}
+								placeholderTextColor={colors.fontB3}
+							/>
+						</View>
+						<Text style={{color: colors.fontB2, margin: 4, marginTop: 8}}>
+							{getStr("deepseekLocalStorageNotice")}
+						</Text>
+						<SectionList
+							style={{flex: 1, marginTop: 8}}
+							sections={Object.entries(
+								history.reduce(
+									(acc, item) => {
+										const date = new Date(
+											item.timestamp ?? 0,
+										).toLocaleDateString();
+										if (!acc[date]) {
+											acc[date] = [];
+										}
+										acc[date].push(item);
+										return acc;
+									},
+									{} as Record<string, Conversation[]>,
+								),
+							)
+								.sort(
+									([dateA], [dateB]) =>
+										new Date(dateB).getTime() - new Date(dateA).getTime(),
+								)
+								.map(([date, data]) => ({
+									title: date,
+									data,
+								}))}
+							renderItem={({item}) => (
+								<Pressable
+									style={{
+										padding: 8,
+										marginStart: 4,
+										backgroundColor:
+											deleteId === item.id
+												? colors.statusWarningOpacity
+												: item.timestamp === conversation.timestamp
+													? colors.themeTransparentGrey
+													: colors.contentBackground,
+										borderRadius: 8,
+									}}
+									onPress={() => {
+										setCurrentIndex(history.findIndex((c) => c.id === item.id));
+										toggleSidebar(false);
+									}}
+									onLongPress={() => {
+										setDeleteId(item.id);
+										Alert.alert(
+											getStr("delete"),
+											getStr("deleteConversationConfirm"),
+											[
+												{
+													text: getStr("cancel"),
+													style: "cancel",
+													onPress: () => {
+														setDeleteId(null);
+													},
+												},
+												{
+													text: getStr("confirm"),
+													onPress: () => {
+														dispatch(deepseekDeleteConversation(item));
+														setDeleteId(null);
+														toggleSidebar(false);
+													},
+												},
+											],
+											{
+												cancelable: true,
+												onDismiss: () => {
+													setDeleteId(null);
+												},
+											},
+										);
+									}}>
+									<Text style={{color: colors.text}}>{item.title}</Text>
+								</Pressable>
+							)}
+							renderSectionHeader={({section: {title}}) => (
+								<Text
+									style={{
+										color: colors.fontB2,
+										backgroundColor: colors.contentBackground,
+										paddingVertical: 4,
+									}}>
+									{title}
+								</Text>
+							)}
+							keyExtractor={(item) => item.id}
+						/>
+						<TouchableOpacity
+							style={{
+								paddingVertical: 12,
+								marginTop: 8,
+								borderRadius: 12,
+								backgroundColor: colors.themeTransparentGrey,
+							}}
+							onPress={createConversation}>
+							<Text style={{color: colors.text, textAlign: "center"}}>
+								{getStr("newConversation")}
 							</Text>
-						)}
-						keyExtractor={(item) => item.id}
-					/>
-					<TouchableOpacity
-						style={{
-							paddingVertical: 12,
-							marginTop: 8,
-							borderRadius: 12,
-							backgroundColor: colors.themeTransparentGrey,
-						}}
-						onPress={createConversation}>
-						<Text style={{color: colors.text, textAlign: "center"}}>
-							{getStr("newConversation")}
-						</Text>
-					</TouchableOpacity>
-					<TouchableOpacity
-						style={{
-							paddingVertical: 12,
-							marginTop: 8,
-							borderRadius: 12,
-							backgroundColor: colors.statusWarningOpacity,
-						}}
-						onPress={deleteAllHistory}>
-						<Text style={{color: colors.statusWarning, textAlign: "center"}}>
-							{getStr("delete") + getStr("all")}
-						</Text>
-					</TouchableOpacity>
-				</Animated.View>
+						</TouchableOpacity>
+						<TouchableOpacity
+							style={{
+								paddingVertical: 12,
+								marginTop: 8,
+								borderRadius: 12,
+								backgroundColor: colors.statusWarningOpacity,
+							}}
+							onPress={deleteAllHistory}>
+							<Text style={{color: colors.statusWarning, textAlign: "center"}}>
+								{getStr("delete") + getStr("all")}
+							</Text>
+						</TouchableOpacity>
+					</Animated.View>
+				</KeyboardAvoidingScreen>
 			</Modal>
 		</KeyboardAvoidingView>
 	);

--- a/apps/thu-info-app/src/ui/home/electricity.tsx
+++ b/apps/thu-info-app/src/ui/home/electricity.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {getStr} from "../../utils/i18n";
 import {useEffect, useState} from "react";
 import {
@@ -52,177 +53,179 @@ export const ElectricityScreen = () => {
 	}, []);
 
 	return (
-		<ScrollView style={{paddingHorizontal: 12, paddingVertical: 16, flex: 1}}>
-			<RoundedView
-				style={{
-					paddingVertical: 12,
-					alignItems: "center",
-					justifyContent: "center",
-				}}>
-				<Text style={{color: colors.fontB3, fontSize: 11}}>
-					{getStr("eleRemainder")}
-				</Text>
-				<Text style={{fontSize: 24, fontWeight: "600", color: colors.text}}>
-					{(() => {
-						switch (remainderStatus) {
-							case "loading":
-								return getStr("loading");
-							case "done":
-								return `${remainderValue} ${getStr("kwh")}`;
-							case "error":
-								return getStr("loadFail");
-						}
-					})()}
-				</Text>
-				<Text style={{color: colors.fontB3, fontSize: 11}}>
-					{getStr("eleRemainderUpdateTime")}
-					{updateTimeValue}
-				</Text>
-				<TouchableOpacity
-					onPress={() => remainderStatus !== "loading" && getRemainder()}
-					style={{position: "absolute", right: 12}}>
-					<IconRefresh width={16} height={16} />
-				</TouchableOpacity>
-			</RoundedView>
-			{false && (
-				<View
+		<KeyboardAvoidingScreen>
+			<ScrollView style={{paddingHorizontal: 12, paddingVertical: 16, flex: 1}}>
+				<RoundedView
 					style={{
-						justifyContent: "center",
+						paddingVertical: 12,
 						alignItems: "center",
-						marginTop: 24,
+						justifyContent: "center",
 					}}>
-					<Text
-						style={{
-							fontSize: 16,
-							fontWeight: "600",
-							color: colors.text,
-							alignSelf: "flex-start",
-							marginLeft: 12,
-						}}>
-						{getStr("eleRecharge")}
+					<Text style={{color: colors.fontB3, fontSize: 11}}>
+						{getStr("eleRemainder")}
 					</Text>
-					<RoundedView style={{marginTop: 8, width: "100%", padding: 16}}>
-						<View style={{flexDirection: "row"}}>
-							{[10, 20, 30].map((price, index) => (
+					<Text style={{fontSize: 24, fontWeight: "600", color: colors.text}}>
+						{(() => {
+							switch (remainderStatus) {
+								case "loading":
+									return getStr("loading");
+								case "done":
+									return `${remainderValue} ${getStr("kwh")}`;
+								case "error":
+									return getStr("loadFail");
+							}
+						})()}
+					</Text>
+					<Text style={{color: colors.fontB3, fontSize: 11}}>
+						{getStr("eleRemainderUpdateTime")}
+						{updateTimeValue}
+					</Text>
+					<TouchableOpacity
+						onPress={() => remainderStatus !== "loading" && getRemainder()}
+						style={{position: "absolute", right: 12}}>
+						<IconRefresh width={16} height={16} />
+					</TouchableOpacity>
+				</RoundedView>
+				{false && (
+					<View
+						style={{
+							justifyContent: "center",
+							alignItems: "center",
+							marginTop: 24,
+						}}>
+						<Text
+							style={{
+								fontSize: 16,
+								fontWeight: "600",
+								color: colors.text,
+								alignSelf: "flex-start",
+								marginLeft: 12,
+							}}>
+							{getStr("eleRecharge")}
+						</Text>
+						<RoundedView style={{marginTop: 8, width: "100%", padding: 16}}>
+							<View style={{flexDirection: "row"}}>
+								{[10, 20, 30].map((price, index) => (
+									<TouchableOpacity
+										style={{
+											borderRadius: 4,
+											paddingHorizontal: 12,
+											paddingVertical: 4,
+											backgroundColor:
+												moneyQuickSelected === price
+													? colors.themePurple
+													: colors.themeLightGrey,
+											marginLeft: index === 0 ? 0 : 8,
+										}}
+										onPress={() => {
+											setMoneyQuickSelected(price);
+											setMoney(String(price));
+										}}
+										disabled={processing}
+										key={price}>
+										<Text
+											style={{
+												color:
+													moneyQuickSelected === price
+														? colors.contentBackground
+														: colors.fontB3,
+											}}>
+											{price} 元
+										</Text>
+									</TouchableOpacity>
+								))}
+							</View>
+							<View
+								style={{
+									flexDirection: "row",
+									alignItems: "center",
+									marginTop: 16,
+								}}>
+								<Text style={{color: colors.text, fontSize: 20}}>￥</Text>
+								<TextInput
+									keyboardType="numeric"
+									placeholder={getStr("enterEleRechargeValue")}
+									placeholderTextColor={colors.fontB3}
+									value={money}
+									onChangeText={(v) => {
+										setMoney(v);
+										setMoneyQuickSelected(undefined);
+									}}
+									editable={!processing}
+									style={{
+										padding: 0,
+										fontSize: 20,
+										marginLeft: 12,
+										color: colors.text,
+									}}
+								/>
+							</View>
+							<View
+								style={{
+									borderBottomWidth: 1,
+									borderBottomColor: colors.themeLightGrey,
+									marginVertical: 12,
+								}}
+							/>
+							<View style={{flexDirection: "row", justifyContent: "center"}}>
 								<TouchableOpacity
 									style={{
+										backgroundColor: valid
+											? colors.primaryLight
+											: colors.mainTheme,
+										alignItems: "center",
+										justifyContent: "center",
+										paddingVertical: 8,
+										paddingHorizontal: 24,
 										borderRadius: 4,
-										paddingHorizontal: 12,
-										paddingVertical: 4,
-										backgroundColor:
-											moneyQuickSelected === price
-												? colors.themePurple
-												: colors.themeLightGrey,
-										marginLeft: index === 0 ? 0 : 8,
 									}}
+									disabled={!valid || processing}
 									onPress={() => {
-										setMoneyQuickSelected(price);
-										setMoney(String(price));
-									}}
-									disabled={processing}
-									key={price}>
+										if (valid && !processing) {
+											setProcessing(true);
+											helper
+												.getEleRechargePayCode(Number(money))
+												.then(doAlipay)
+												.then(() => {
+													setProcessing(false);
+													setMoney("");
+												})
+												.catch(() => {
+													Snackbar.show({
+														text: getStr("payFailure"),
+														duration: Snackbar.LENGTH_INDEFINITE,
+														action: {text: getStr("ok")},
+													});
+													setProcessing(false);
+												});
+										}
+									}}>
 									<Text
 										style={{
 											color:
-												moneyQuickSelected === price
+												valid && !processing
 													? colors.contentBackground
-													: colors.fontB3,
+													: colors.themeGrey,
+											fontSize: 16,
 										}}>
-										{price} 元
+										{getStr(processing ? "processing" : "payForElectricity")}
 									</Text>
 								</TouchableOpacity>
-							))}
-						</View>
-						<View
+							</View>
+						</RoundedView>
+						<Text
 							style={{
-								flexDirection: "row",
-								alignItems: "center",
-								marginTop: 16,
+								textAlign: "left",
+								fontSize: 14,
+								color: colors.statusWarning,
+								marginHorizontal: 16,
+								marginTop: 32,
 							}}>
-							<Text style={{color: colors.text, fontSize: 20}}>￥</Text>
-							<TextInput
-								keyboardType="numeric"
-								placeholder={getStr("enterEleRechargeValue")}
-								placeholderTextColor={colors.fontB3}
-								value={money}
-								onChangeText={(v) => {
-									setMoney(v);
-									setMoneyQuickSelected(undefined);
-								}}
-								editable={!processing}
-								style={{
-									padding: 0,
-									fontSize: 20,
-									marginLeft: 12,
-									color: colors.text,
-								}}
-							/>
-						</View>
-						<View
-							style={{
-								borderBottomWidth: 1,
-								borderBottomColor: colors.themeLightGrey,
-								marginVertical: 12,
-							}}
-						/>
-						<View style={{flexDirection: "row", justifyContent: "center"}}>
-							<TouchableOpacity
-								style={{
-									backgroundColor: valid
-										? colors.primaryLight
-										: colors.mainTheme,
-									alignItems: "center",
-									justifyContent: "center",
-									paddingVertical: 8,
-									paddingHorizontal: 24,
-									borderRadius: 4,
-								}}
-								disabled={!valid || processing}
-								onPress={() => {
-									if (valid && !processing) {
-										setProcessing(true);
-										helper
-											.getEleRechargePayCode(Number(money))
-											.then(doAlipay)
-											.then(() => {
-												setProcessing(false);
-												setMoney("");
-											})
-											.catch(() => {
-												Snackbar.show({
-													text: getStr("payFailure"),
-													duration: Snackbar.LENGTH_INDEFINITE,
-													action: {text: getStr("ok")},
-												});
-												setProcessing(false);
-											});
-									}
-								}}>
-								<Text
-									style={{
-										color:
-											valid && !processing
-												? colors.contentBackground
-												: colors.themeGrey,
-										fontSize: 16,
-									}}>
-									{getStr(processing ? "processing" : "payForElectricity")}
-								</Text>
-							</TouchableOpacity>
-						</View>
-					</RoundedView>
-					<Text
-						style={{
-							textAlign: "left",
-							fontSize: 14,
-							color: colors.statusWarning,
-							marginHorizontal: 16,
-							marginTop: 32,
-						}}>
-						{getStr("eleRechargeHint")}
-					</Text>
-				</View>
-			)}
-		</ScrollView>
+							{getStr("eleRechargeHint")}
+						</Text>
+					</View>
+				)}
+			</ScrollView>
+		</KeyboardAvoidingScreen>
 	);
 };

--- a/apps/thu-info-app/src/ui/home/form.tsx
+++ b/apps/thu-info-app/src/ui/home/form.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {ThemedRefreshControl} from "../../components/themedRefreshControl";
 import {useEffect, useState} from "react";
 import {
@@ -182,73 +183,75 @@ export const FormScreen = ({
 	useEffect(() => fetchForm(url), [url]);
 
 	return (
-		<ScrollView
-			style={style.container}
-			showsVerticalScrollIndicator={false}
-			refreshControl={
-				<ThemedRefreshControl
-					refreshing={refreshing}
-				/>
-			}>
-			<View style={[style.titleContainer, {marginTop: 16}]}>
-				<View
-					style={[style.titleIcon, {backgroundColor: colors.statusWarning}]}
-				/>
-				<Text style={style.titleStyle}>{getStr("generalImpression")}</Text>
-			</View>
-			{evaluationForm && (
-				<RoundedView>
-					<Text
+		<KeyboardAvoidingScreen>
+			<ScrollView
+				style={style.container}
+				showsVerticalScrollIndicator={false}
+				refreshControl={
+					<ThemedRefreshControl
+						refreshing={refreshing}
+					/>
+				}>
+				<View style={[style.titleContainer, {marginTop: 16}]}>
+					<View
+						style={[style.titleIcon, {backgroundColor: colors.statusWarning}]}
+					/>
+					<Text style={style.titleStyle}>{getStr("generalImpression")}</Text>
+				</View>
+				{evaluationForm && (
+					<RoundedView>
+						<Text
+							style={{
+								color: colors.text,
+								marginTop: 12,
+								fontSize: 20,
+								fontWeight: "bold",
+								textAlign: "center",
+							}}>
+							{route.params.name}
+						</Text>
+						<View style={{marginTop: 8, alignItems: "center"}}>
+							<StarRating scoreRef={evaluationForm.overall.score} />
+						</View>
+					</RoundedView>
+				)}
+				<RoundedView style={{marginTop: 8, padding: 16}}>
+					<TextInput
 						style={{
+							height: 100,
+							textAlign: "left",
+							alignSelf: "stretch",
+							textAlignVertical: "top",
 							color: colors.text,
-							marginTop: 12,
-							fontSize: 20,
-							fontWeight: "bold",
-							textAlign: "center",
-						}}>
-						{route.params.name}
-					</Text>
-					<View style={{marginTop: 8, alignItems: "center"}}>
-						<StarRating scoreRef={evaluationForm.overall.score} />
-					</View>
+						}}
+						multiline={true}
+						placeholder={getStr("moreSuggestionsToCourse")}
+						placeholderTextColor={colors.fontB3}
+						defaultValue={evaluationForm?.overall?.suggestion ?? ""}
+						onChangeText={(text) => {
+							if (evaluationForm) {
+								evaluationForm.overall.suggestion = text;
+							}
+						}}
+					/>
 				</RoundedView>
-			)}
-			<RoundedView style={{marginTop: 8, padding: 16}}>
-				<TextInput
-					style={{
-						height: 100,
-						textAlign: "left",
-						alignSelf: "stretch",
-						textAlignVertical: "top",
-						color: colors.text,
-					}}
-					multiline={true}
-					placeholder={getStr("moreSuggestionsToCourse")}
-					placeholderTextColor={colors.fontB3}
-					defaultValue={evaluationForm?.overall?.suggestion ?? ""}
-					onChangeText={(text) => {
-						if (evaluationForm) {
-							evaluationForm.overall.suggestion = text;
-						}
-					}}
-				/>
-			</RoundedView>
-			{evaluationForm && renderEvaluation(evaluationForm.teachers, "teacher")}
-			{evaluationForm &&
-				renderEvaluation(evaluationForm.assistants, "assistant")}
-			<TouchableOpacity
-				style={[
-					style.buttonStyle,
-					{
-						backgroundColor:
-							evaluationForm === undefined ? "lightgrey" : colors.primaryLight,
-					},
-				]}
-				onPress={post}
-				disabled={evaluationForm === undefined}>
-				<Text style={style.buttonTextStyle}>{getStr("post")}</Text>
-			</TouchableOpacity>
-		</ScrollView>
+				{evaluationForm && renderEvaluation(evaluationForm.teachers, "teacher")}
+				{evaluationForm &&
+					renderEvaluation(evaluationForm.assistants, "assistant")}
+				<TouchableOpacity
+					style={[
+						style.buttonStyle,
+						{
+							backgroundColor:
+								evaluationForm === undefined ? "lightgrey" : colors.primaryLight,
+						},
+					]}
+					onPress={post}
+					disabled={evaluationForm === undefined}>
+					<Text style={style.buttonTextStyle}>{getStr("post")}</Text>
+				</TouchableOpacity>
+			</ScrollView>
+		</KeyboardAvoidingScreen>
 	);
 };
 

--- a/apps/thu-info-app/src/ui/home/networkLogin.tsx
+++ b/apps/thu-info-app/src/ui/home/networkLogin.tsx
@@ -55,6 +55,7 @@ export const NetworkLoginScreen = ({navigation}: {navigation: RootNav}) => {
 
 	return (
 		<KeyboardAvoidingView
+			style={{flex: 1}}
 			behavior={Platform.OS === "ios" ? "padding" : "height"}>
 			<ScrollView
 				refreshControl={

--- a/apps/thu-info-app/src/ui/home/networkOnlineDevices.tsx
+++ b/apps/thu-info-app/src/ui/home/networkOnlineDevices.tsx
@@ -6,7 +6,7 @@ import { getStr } from "../../utils/i18n";
 import { GestureHandlerRootView, RefreshControl, ScrollView } from "react-native-gesture-handler";
 import {
 	KeyboardAvoidingView,
-	// Platform,
+	Platform,
 	Switch,
 	Text,
 	TextInput,
@@ -148,8 +148,7 @@ export const NetworkOnlineDevicesScreen = ({navigation}: {navigation: RootNav}) 
 	return (
 		<KeyboardAvoidingView
 			style={{ flex: 1 }}
-			// behavior={Platform.OS === "ios" ? "padding" : "height"}
-			behavior="padding"
+			behavior={Platform.OS === "android" ? "height" : "padding"}
 			keyboardVerticalOffset={headerHeight}>
 			<GestureHandlerRootView style={{ flex: 1, flexDirection: "column" }}>
 				<ScrollView

--- a/apps/thu-info-app/src/ui/home/peekScore.tsx
+++ b/apps/thu-info-app/src/ui/home/peekScore.tsx
@@ -1,10 +1,10 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {getStr} from "../../utils/i18n";
 import {
 	Text,
 	TextInput,
 	TouchableOpacity,
 	useColorScheme,
-	View,
 } from "react-native";
 import {helper} from "../../redux/store";
 import themes from "../../assets/themes/themes";
@@ -20,7 +20,7 @@ export const PeekScoreScreen = () => {
 	const [courseGrade, setCourseGrade] = useState("");
 	const [querying, setQuerying] = useState(false);
 	return (
-		<View
+		<KeyboardAvoidingScreen
 			style={{
 				flex: 1,
 				marginHorizontal: 12,
@@ -102,6 +102,6 @@ export const PeekScoreScreen = () => {
 					</Text>
 				</RoundedView>
 			</TouchableOpacity>
-		</View>
+		</KeyboardAvoidingScreen>
 	);
 };

--- a/apps/thu-info-app/src/ui/home/reservesLibWelcome.tsx
+++ b/apps/thu-info-app/src/ui/home/reservesLibWelcome.tsx
@@ -1,4 +1,5 @@
 import {RootNav} from "../../components/Root";
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {
 	TextInput,
 	TouchableOpacity,
@@ -79,7 +80,7 @@ export const ReservesLibWelcomeScreen = (props: {navigation: RootNav}) => {
 		});
 	}, []);
 
-	return paginatedRefreshListScreen(
+	const content = paginatedRefreshListScreen(
 		async (_: PropsWithChildren<{navigation: RootNav}>, page) =>
 			search.length === 0
 				? []
@@ -135,4 +136,5 @@ export const ReservesLibWelcomeScreen = (props: {navigation: RootNav}) => {
 			</View>
 		),
 	)(props);
+	return <KeyboardAvoidingScreen>{content}</KeyboardAvoidingScreen>;
 };

--- a/apps/thu-info-app/src/ui/home/thos.tsx
+++ b/apps/thu-info-app/src/ui/home/thos.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {ThemedRefreshControl} from "../../components/themedRefreshControl";
 import React, {useCallback, useEffect, useRef, useState} from "react";
 import {
@@ -347,298 +348,300 @@ export const ThosScreen = ({navigation}: {navigation: RootNav}) => {
 	const page = tab === "services" ? services : tasks[tab];
 	const complete = page?.complete && (tab !== "todo" || tasks.active?.complete);
 	return (
-		<ScrollView
-			testID="thos-dashboard"
-			style={{flex: 1, backgroundColor: colors.themeBackground}}
-			onLayout={(event) => setWidth(event.nativeEvent.layout.width)}
-			keyboardShouldPersistTaps="handled"
-			refreshControl={
-				<ThemedRefreshControl
-					refreshing={busy}
-					onRefresh={load}
-				/>
-			}
-			contentContainerStyle={{
-				padding: 16,
-				paddingBottom: 40,
-				maxWidth: 1100,
-				width: "100%",
-				alignSelf: "center",
-			}}>
-			{demo && (
-				<Text style={{color: colors.statusWarning, marginVertical: 8}}>
-					{getStr("thosDemoNotice")}
-				</Text>
-			)}
-			{!userId ? (
-				<Chip title={getStr("thosLogin")} onPress={login} />
-			) : (
-				<>
-					<View
-						style={{
-							flexDirection: "row",
-							flexWrap: "wrap",
-							marginVertical: 10,
-						}}>
-						{primaryTaskKinds.map((kind) => (
-							<TouchableOpacity
-								key={kind}
-								onPress={() => showTasks(kind)}
-								style={{
-									flex: 1,
-									minWidth: 90,
-									padding: 14,
-									margin: 4,
-									borderRadius: 12,
-									alignItems: "center",
-									backgroundColor:
-										tab === kind ? colors.mainTheme : colors.contentBackground,
-								}}>
-								<Text
-									style={{
-										fontSize: 28,
-										fontWeight: "700",
-										color: tab === kind ? "white" : colors.mainTheme,
-									}}>
-									{counts?.[kind] ?? "—"}
-								</Text>
-								<Text
-									style={{
-										color: tab === kind ? "white" : colors.text,
-										marginTop: 6,
-									}}>
-									{getTaskLabel(kind)}
-								</Text>
-							</TouchableOpacity>
-						))}
-					</View>
-					<View style={{flexDirection: "row", flexWrap: "wrap"}}>
-						<Chip
-							title={`${getStr("thosDrafts")} ${counts?.drafts ?? "—"}`}
-							onPress={() => showTasks("drafts")}
-							selected={tab === "drafts"}
-							style={{flex: 1, minWidth: 90, alignItems: "center"}}
-						/>
-						<Chip
-							title={`${getStr("thosUnread")} ${counts?.unread ?? "—"}`}
-							onPress={() => showTasks("unread")}
-							selected={tab === "unread"}
-							style={{flex: 1, minWidth: 90, alignItems: "center"}}
-						/>
-						<Chip
-							title={getStr("thosPhases")}
-							onPress={() => showTasks("phases")}
-							selected={tab === "phases"}
-							style={{flex: 1, minWidth: 90, alignItems: "center"}}
-						/>
-					</View>
-					{error && (
-						<Text
-							testID="thos-error"
-							style={{color: colors.statusError, padding: 12}}>
-							{error}
-						</Text>
-					)}
-					<View
-						style={{
-							flexDirection: "row",
-							flexWrap: "wrap",
-							justifyContent: "space-between",
-							marginTop: 12,
-						}}>
-						<Chip
-							title={`${getStr("thosFavorites")} ${favorites.length}`}
-							style={{flex: 1, alignItems: "center"}}
-							selected={tab === "services" && onlyFavorites}
-							onPress={() => showServices(true)}
-						/>
-						<Chip
-							title={getStr("thosAllServices")}
-							style={{flex: 1, alignItems: "center"}}
-							selected={tab === "services" && !onlyFavorites}
-							onPress={() => showServices(false)}
-						/>
-					</View>
-					<TextInput
-						testID="thos-search"
-						accessibilityLabel={getStr("thosSearchAccessibility")}
-						value={query}
-						onChangeText={setQuery}
-						placeholder={
-							tab === "services"
-								? onlyFavorites
-									? getStr("thosSearchFavorites")
-									: getStr("thosSearchServices")
-								: getStr("thosSearchTasks")
-						}
-						placeholderTextColor={colors.fontB2}
-						returnKeyType="search"
-						submitBehavior="blurAndSubmit"
-						style={{
-							color: colors.text,
-							borderColor: colors.inputBorder,
-							borderWidth: 1,
-							borderRadius: 12,
-							padding: 12,
-							marginVertical: 12,
-						}}
+		<KeyboardAvoidingScreen>
+			<ScrollView
+				testID="thos-dashboard"
+				style={{flex: 1, backgroundColor: colors.themeBackground}}
+				onLayout={(event) => setWidth(event.nativeEvent.layout.width)}
+				keyboardShouldPersistTaps="handled"
+				refreshControl={
+					<ThemedRefreshControl
+						refreshing={busy}
+						onRefresh={load}
 					/>
-					{!(tab === "services" && onlyFavorites) && !complete && (
-						<Text style={{color: colors.fontB2, marginBottom: 8}}>
-							{!page ? getStr("thosReading") : getStr("thosPartialResults")}
-						</Text>
-					)}
-					<View style={{flexDirection: "row", flexWrap: "wrap", gap: 12}}>
-						{tab === "services"
-							? serviceRows.map((item) => (
-									<View
-										key={item.id}
+				}
+				contentContainerStyle={{
+					padding: 16,
+					paddingBottom: 40,
+					maxWidth: 1100,
+					width: "100%",
+					alignSelf: "center",
+				}}>
+				{demo && (
+					<Text style={{color: colors.statusWarning, marginVertical: 8}}>
+						{getStr("thosDemoNotice")}
+					</Text>
+				)}
+				{!userId ? (
+					<Chip title={getStr("thosLogin")} onPress={login} />
+				) : (
+					<>
+						<View
+							style={{
+								flexDirection: "row",
+								flexWrap: "wrap",
+								marginVertical: 10,
+							}}>
+							{primaryTaskKinds.map((kind) => (
+								<TouchableOpacity
+									key={kind}
+									onPress={() => showTasks(kind)}
+									style={{
+										flex: 1,
+										minWidth: 90,
+										padding: 14,
+										margin: 4,
+										borderRadius: 12,
+										alignItems: "center",
+										backgroundColor:
+											tab === kind ? colors.mainTheme : colors.contentBackground,
+									}}>
+									<Text
 										style={{
-											width:
-												width >= 900 ? "31%" : width >= 600 ? "47%" : "100%",
-											borderRadius: 12,
-											padding: 16,
-											backgroundColor: colors.contentBackground,
+											fontSize: 28,
+											fontWeight: "700",
+											color: tab === kind ? "white" : colors.mainTheme,
 										}}>
-										<View
-											style={{flexDirection: "row", alignItems: "flex-start"}}>
-											<TouchableOpacity
-												onPress={() =>
-													navigation.navigate("ThosServiceDetail", {
-														service: item,
-														accountId: userId,
-													})
-												}
-												accessibilityRole="button"
-												style={{flex: 1}}>
-												<Text
-													style={{
-														color: colors.text,
-														fontSize: 17,
-														fontWeight: "600",
-													}}>
-													{item.name}
-												</Text>
-											</TouchableOpacity>
-											<TouchableOpacity
-												testID={`thos-favorite-${item.id}`}
-												accessibilityRole="button"
-												accessibilityLabel={
-													favorites.includes(item.id)
-														? getStr("thosCancelFavorite")
-														: getStr("thosFavoriteService")
-												}
-												onPress={() => favorite(item.id)}
-												style={{padding: 4, marginLeft: 8}}>
-												{favorites.includes(item.id) ? (
-													<IconStarActive width={24} height={24} />
-												) : (
-													<IconStar width={24} height={24} />
-												)}
-											</TouchableOpacity>
-										</View>
-										<Text style={{color: colors.fontB2, marginVertical: 10}}>
-											{item.department || getStr("thosDepartmentUnavailable")}
-										</Text>
-									</View>
-								))
-							: taskRows.map((item) => (
-									<TouchableOpacity
-										key={`${item.kind}:${item.key}`}
-										onPress={() =>
-											navigation.navigate("ThosTaskDetail", {
-												task: item,
-												accountId: userId,
-											})
-										}
+										{counts?.[kind] ?? "—"}
+									</Text>
+									<Text
 										style={{
-											width: "100%",
-											padding: 16,
-											borderRadius: 12,
-											backgroundColor: colors.contentBackground,
+											color: tab === kind ? "white" : colors.text,
+											marginTop: 6,
 										}}>
-										<Text
-											style={{
-												color: colors.text,
-												fontSize: 17,
-												fontWeight: "600",
-											}}>
-											{item.title}
-										</Text>
-										<Text style={{color: colors.mainTheme, marginVertical: 8}}>
-											{getThosTaskStatusLabel(item.status)}
-											{item.workflowStatus
-												? ` · ${getThosTaskStatusLabel(item.workflowStatus)}`
-												: ""}
-											{item.node ? ` · ${item.node}` : ""}
-										</Text>
-										{!!item.summary && (
-											<Text style={{color: colors.fontB2, marginBottom: 6}}>
-												{getStr("thosSummary")}
-												{item.summary}
-											</Text>
-										)}
-										{item.progress !== undefined && (
-											<>
-												<View
-													accessibilityLabel={getStr("thosProgress").replace(
-														"{0}",
-														String(item.progress),
-													)}
-													style={{
-														height: 5,
-														borderRadius: 3,
-														backgroundColor: colors.themeGrey,
-													}}>
-													<View
-														style={{
-															height: 5,
-															width: `${item.progress}%`,
-															backgroundColor: colors.mainTheme,
-															borderRadius: 3,
-														}}
-													/>
-												</View>
-												<Text style={{color: colors.fontB2, marginTop: 6}}>
-													{item.progress}%
-												</Text>
-											</>
-										)}
-										{!!item.date && (
-											<Text style={{color: colors.fontB2, marginTop: 6}}>
-												{item.kind === "completed"
-													? getStr("thosCompletionTime")
-													: item.kind === "drafts"
-														? getStr("thosLastModifiedTime")
-														: getStr("thosApplicationTime")}
-												{getStr("colonMark")}
-												{item.date}
-											</Text>
-										)}
-									</TouchableOpacity>
-								))}
-					</View>
-					{page &&
-						(tab === "services" ? serviceRows : taskRows).length === 0 && (
-							<Text style={{padding: 20, color: colors.fontB2}}>
-								{tab === "services" && onlyFavorites && !query && complete
-									? getStr("thosNoFavorites")
-									: query
-										? getStr("thosNoMatch")
-										: complete
-											? getStr("thosNoTasks")
-											: getStr("thosNoResults")}
+										{getTaskLabel(kind)}
+									</Text>
+								</TouchableOpacity>
+							))}
+						</View>
+						<View style={{flexDirection: "row", flexWrap: "wrap"}}>
+							<Chip
+								title={`${getStr("thosDrafts")} ${counts?.drafts ?? "—"}`}
+								onPress={() => showTasks("drafts")}
+								selected={tab === "drafts"}
+								style={{flex: 1, minWidth: 90, alignItems: "center"}}
+							/>
+							<Chip
+								title={`${getStr("thosUnread")} ${counts?.unread ?? "—"}`}
+								onPress={() => showTasks("unread")}
+								selected={tab === "unread"}
+								style={{flex: 1, minWidth: 90, alignItems: "center"}}
+							/>
+							<Chip
+								title={getStr("thosPhases")}
+								onPress={() => showTasks("phases")}
+								selected={tab === "phases"}
+								style={{flex: 1, minWidth: 90, alignItems: "center"}}
+							/>
+						</View>
+						{error && (
+							<Text
+								testID="thos-error"
+								style={{color: colors.statusError, padding: 12}}>
+								{error}
 							</Text>
 						)}
-					{updated && (
-						<Text style={{color: colors.fontB2, marginTop: 12}}>
-							{getStr("thosRefreshTime")}
-							{new Date(updated).toLocaleTimeString()}
-						</Text>
-					)}
-				</>
-			)}
-		</ScrollView>
+						<View
+							style={{
+								flexDirection: "row",
+								flexWrap: "wrap",
+								justifyContent: "space-between",
+								marginTop: 12,
+							}}>
+							<Chip
+								title={`${getStr("thosFavorites")} ${favorites.length}`}
+								style={{flex: 1, alignItems: "center"}}
+								selected={tab === "services" && onlyFavorites}
+								onPress={() => showServices(true)}
+							/>
+							<Chip
+								title={getStr("thosAllServices")}
+								style={{flex: 1, alignItems: "center"}}
+								selected={tab === "services" && !onlyFavorites}
+								onPress={() => showServices(false)}
+							/>
+						</View>
+						<TextInput
+							testID="thos-search"
+							accessibilityLabel={getStr("thosSearchAccessibility")}
+							value={query}
+							onChangeText={setQuery}
+							placeholder={
+								tab === "services"
+									? onlyFavorites
+										? getStr("thosSearchFavorites")
+										: getStr("thosSearchServices")
+									: getStr("thosSearchTasks")
+							}
+							placeholderTextColor={colors.fontB2}
+							returnKeyType="search"
+							submitBehavior="blurAndSubmit"
+							style={{
+								color: colors.text,
+								borderColor: colors.inputBorder,
+								borderWidth: 1,
+								borderRadius: 12,
+								padding: 12,
+								marginVertical: 12,
+							}}
+						/>
+						{!(tab === "services" && onlyFavorites) && !complete && (
+							<Text style={{color: colors.fontB2, marginBottom: 8}}>
+								{!page ? getStr("thosReading") : getStr("thosPartialResults")}
+							</Text>
+						)}
+						<View style={{flexDirection: "row", flexWrap: "wrap", gap: 12}}>
+							{tab === "services"
+								? serviceRows.map((item) => (
+										<View
+											key={item.id}
+											style={{
+												width:
+													width >= 900 ? "31%" : width >= 600 ? "47%" : "100%",
+												borderRadius: 12,
+												padding: 16,
+												backgroundColor: colors.contentBackground,
+											}}>
+											<View
+												style={{flexDirection: "row", alignItems: "flex-start"}}>
+												<TouchableOpacity
+													onPress={() =>
+														navigation.navigate("ThosServiceDetail", {
+															service: item,
+															accountId: userId,
+														})
+													}
+													accessibilityRole="button"
+													style={{flex: 1}}>
+													<Text
+														style={{
+															color: colors.text,
+															fontSize: 17,
+															fontWeight: "600",
+														}}>
+														{item.name}
+													</Text>
+												</TouchableOpacity>
+												<TouchableOpacity
+													testID={`thos-favorite-${item.id}`}
+													accessibilityRole="button"
+													accessibilityLabel={
+														favorites.includes(item.id)
+															? getStr("thosCancelFavorite")
+															: getStr("thosFavoriteService")
+													}
+													onPress={() => favorite(item.id)}
+													style={{padding: 4, marginLeft: 8}}>
+													{favorites.includes(item.id) ? (
+														<IconStarActive width={24} height={24} />
+													) : (
+														<IconStar width={24} height={24} />
+													)}
+												</TouchableOpacity>
+											</View>
+											<Text style={{color: colors.fontB2, marginVertical: 10}}>
+												{item.department || getStr("thosDepartmentUnavailable")}
+											</Text>
+										</View>
+									))
+								: taskRows.map((item) => (
+										<TouchableOpacity
+											key={`${item.kind}:${item.key}`}
+											onPress={() =>
+												navigation.navigate("ThosTaskDetail", {
+													task: item,
+													accountId: userId,
+												})
+											}
+											style={{
+												width: "100%",
+												padding: 16,
+												borderRadius: 12,
+												backgroundColor: colors.contentBackground,
+											}}>
+											<Text
+												style={{
+													color: colors.text,
+													fontSize: 17,
+													fontWeight: "600",
+												}}>
+												{item.title}
+											</Text>
+											<Text style={{color: colors.mainTheme, marginVertical: 8}}>
+												{getThosTaskStatusLabel(item.status)}
+												{item.workflowStatus
+													? ` · ${getThosTaskStatusLabel(item.workflowStatus)}`
+													: ""}
+												{item.node ? ` · ${item.node}` : ""}
+											</Text>
+											{!!item.summary && (
+												<Text style={{color: colors.fontB2, marginBottom: 6}}>
+													{getStr("thosSummary")}
+													{item.summary}
+												</Text>
+											)}
+											{item.progress !== undefined && (
+												<>
+													<View
+														accessibilityLabel={getStr("thosProgress").replace(
+															"{0}",
+															String(item.progress),
+														)}
+														style={{
+															height: 5,
+															borderRadius: 3,
+															backgroundColor: colors.themeGrey,
+														}}>
+														<View
+															style={{
+																height: 5,
+																width: `${item.progress}%`,
+																backgroundColor: colors.mainTheme,
+																borderRadius: 3,
+															}}
+														/>
+													</View>
+													<Text style={{color: colors.fontB2, marginTop: 6}}>
+														{item.progress}%
+													</Text>
+												</>
+											)}
+											{!!item.date && (
+												<Text style={{color: colors.fontB2, marginTop: 6}}>
+													{item.kind === "completed"
+														? getStr("thosCompletionTime")
+														: item.kind === "drafts"
+															? getStr("thosLastModifiedTime")
+															: getStr("thosApplicationTime")}
+													{getStr("colonMark")}
+													{item.date}
+												</Text>
+											)}
+										</TouchableOpacity>
+									))}
+						</View>
+						{page &&
+							(tab === "services" ? serviceRows : taskRows).length === 0 && (
+								<Text style={{padding: 20, color: colors.fontB2}}>
+									{tab === "services" && onlyFavorites && !query && complete
+										? getStr("thosNoFavorites")
+										: query
+											? getStr("thosNoMatch")
+											: complete
+												? getStr("thosNoTasks")
+												: getStr("thosNoResults")}
+								</Text>
+							)}
+						{updated && (
+							<Text style={{color: colors.fontB2, marginTop: 12}}>
+								{getStr("thosRefreshTime")}
+								{new Date(updated).toLocaleTimeString()}
+							</Text>
+						)}
+					</>
+				)}
+			</ScrollView>
+		</KeyboardAvoidingScreen>
 	);
 };
 

--- a/apps/thu-info-app/src/ui/home/water.tsx
+++ b/apps/thu-info-app/src/ui/home/water.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {useEffect, useState} from "react";
 import {
 	Linking,
@@ -72,318 +73,320 @@ export const WaterScreen = ({
 		address.trim().length === 0;
 
 	return (
-		<ScrollView style={{flex: 1, paddingHorizontal: 12, paddingVertical: 16}}>
-			<RoundedView style={{padding: 16}}>
-				<View
-					style={{
-						flexDirection: "row",
-						alignItems: "center",
-						justifyContent: "space-between",
-					}}>
-					<Text
-						style={{
-							color: colors.text,
-							fontSize: 16,
-							lineHeight: 24,
-						}}>
-						档案号
-					</Text>
-					<TextInput
-						style={{
-							backgroundColor: colors.contentBackground,
-							color: colors.fontB3,
-							textAlign: "right",
-							fontSize: 16,
-							lineHeight: 24,
-							padding: 0,
-						}}
-						value={waterId ?? ""}
-						onChangeText={(value) =>
-							dispatch(configSet({key: "waterId", value}))
-						}
-						onSubmitEditing={load}
-						placeholder="请输入"
-						placeholderTextColor={colors.fontB3}
-					/>
-				</View>
-				<View
-					style={[
-						style.separator,
-						{
-							marginHorizontal: 0,
-						},
-					]}
-				/>
-				<View
-					style={{
-						flexDirection: "row",
-						alignItems: "center",
-						justifyContent: "space-between",
-					}}>
-					<Text
-						style={{
-							color: colors.text,
-							fontSize: 16,
-							lineHeight: 24,
-						}}>
-						联系人
-					</Text>
-					<Text
-						style={{
-							color: colors.fontB3,
-							fontSize: 16,
-							lineHeight: 24,
-						}}>
-						{correspondent}
-					</Text>
-				</View>
-				<View
-					style={[
-						style.separator,
-						{
-							marginHorizontal: 0,
-						},
-					]}
-				/>
-				<View
-					style={{
-						flexDirection: "row",
-						alignItems: "center",
-						justifyContent: "space-between",
-					}}>
-					<Text
-						style={{
-							color: colors.text,
-							fontSize: 16,
-							lineHeight: 24,
-						}}>
-						送水地址
-					</Text>
-					<Text
-						style={{
-							color: colors.fontB3,
-							fontSize: 16,
-							lineHeight: 24,
-						}}>
-						{address}
-					</Text>
-				</View>
-			</RoundedView>
-			<RoundedView style={{padding: 16, marginTop: 16}}>
-				<View
-					style={{
-						flexDirection: "row",
-						alignItems: "center",
-						justifyContent: "space-between",
-					}}>
-					<Text
-						style={{
-							color: colors.text,
-							fontSize: 16,
-							lineHeight: 24,
-						}}>
-						订水量
-					</Text>
+		<KeyboardAvoidingScreen>
+			<ScrollView style={{flex: 1, paddingHorizontal: 12, paddingVertical: 16}}>
+				<RoundedView style={{padding: 16}}>
 					<View
 						style={{
-							borderRadius: 4,
-							borderWidth: 1,
-							borderColor: colors.themeGrey,
 							flexDirection: "row",
+							alignItems: "center",
+							justifyContent: "space-between",
 						}}>
-						<TouchableOpacity
-							disabled={waterNumber <= 0}
-							onPress={() => setWaterNumber((v) => v - 1)}>
-							<Text
-								style={{
-									color: waterNumber <= 0 ? colors.fontB3 : colors.text,
-									width: 24,
-									height: 24,
-									textAlign: "center",
-									textAlignVertical: "center",
-									fontSize: 16,
-								}}>
-								-
-							</Text>
-						</TouchableOpacity>
-						<View style={{width: 1, backgroundColor: colors.themeGrey}} />
 						<Text
 							style={{
 								color: colors.text,
-								width: 40,
-								height: 24,
-								textAlign: "center",
-								textAlignVertical: "center",
 								fontSize: 16,
+								lineHeight: 24,
 							}}>
-							{waterNumber}
+							档案号
 						</Text>
-						<View style={{width: 1, backgroundColor: colors.themeGrey}} />
-						<TouchableOpacity onPress={() => setWaterNumber((v) => v + 1)}>
+						<TextInput
+							style={{
+								backgroundColor: colors.contentBackground,
+								color: colors.fontB3,
+								textAlign: "right",
+								fontSize: 16,
+								lineHeight: 24,
+								padding: 0,
+							}}
+							value={waterId ?? ""}
+							onChangeText={(value) =>
+								dispatch(configSet({key: "waterId", value}))
+							}
+							onSubmitEditing={load}
+							placeholder="请输入"
+							placeholderTextColor={colors.fontB3}
+						/>
+					</View>
+					<View
+						style={[
+							style.separator,
+							{
+								marginHorizontal: 0,
+							},
+						]}
+					/>
+					<View
+						style={{
+							flexDirection: "row",
+							alignItems: "center",
+							justifyContent: "space-between",
+						}}>
+						<Text
+							style={{
+								color: colors.text,
+								fontSize: 16,
+								lineHeight: 24,
+							}}>
+							联系人
+						</Text>
+						<Text
+							style={{
+								color: colors.fontB3,
+								fontSize: 16,
+								lineHeight: 24,
+							}}>
+							{correspondent}
+						</Text>
+					</View>
+					<View
+						style={[
+							style.separator,
+							{
+								marginHorizontal: 0,
+							},
+						]}
+					/>
+					<View
+						style={{
+							flexDirection: "row",
+							alignItems: "center",
+							justifyContent: "space-between",
+						}}>
+						<Text
+							style={{
+								color: colors.text,
+								fontSize: 16,
+								lineHeight: 24,
+							}}>
+							送水地址
+						</Text>
+						<Text
+							style={{
+								color: colors.fontB3,
+								fontSize: 16,
+								lineHeight: 24,
+							}}>
+							{address}
+						</Text>
+					</View>
+				</RoundedView>
+				<RoundedView style={{padding: 16, marginTop: 16}}>
+					<View
+						style={{
+							flexDirection: "row",
+							alignItems: "center",
+							justifyContent: "space-between",
+						}}>
+						<Text
+							style={{
+								color: colors.text,
+								fontSize: 16,
+								lineHeight: 24,
+							}}>
+							订水量
+						</Text>
+						<View
+							style={{
+								borderRadius: 4,
+								borderWidth: 1,
+								borderColor: colors.themeGrey,
+								flexDirection: "row",
+							}}>
+							<TouchableOpacity
+								disabled={waterNumber <= 0}
+								onPress={() => setWaterNumber((v) => v - 1)}>
+								<Text
+									style={{
+										color: waterNumber <= 0 ? colors.fontB3 : colors.text,
+										width: 24,
+										height: 24,
+										textAlign: "center",
+										textAlignVertical: "center",
+										fontSize: 16,
+									}}>
+									-
+								</Text>
+							</TouchableOpacity>
+							<View style={{width: 1, backgroundColor: colors.themeGrey}} />
 							<Text
 								style={{
 									color: colors.text,
-									width: 24,
+									width: 40,
 									height: 24,
 									textAlign: "center",
 									textAlignVertical: "center",
 									fontSize: 16,
 								}}>
-								+
+								{waterNumber}
 							</Text>
-						</TouchableOpacity>
+							<View style={{width: 1, backgroundColor: colors.themeGrey}} />
+							<TouchableOpacity onPress={() => setWaterNumber((v) => v + 1)}>
+								<Text
+									style={{
+										color: colors.text,
+										width: 24,
+										height: 24,
+										textAlign: "center",
+										textAlignVertical: "center",
+										fontSize: 16,
+									}}>
+									+
+								</Text>
+							</TouchableOpacity>
+						</View>
 					</View>
-				</View>
-				<View
-					style={[
-						style.separator,
-						{
-							marginHorizontal: 0,
-						},
-					]}
-				/>
-				<TouchableOpacity
-					onPress={() => navigation.navigate("WaterSelectBrand")}
-					style={{
-						flexDirection: "row",
-						alignItems: "center",
-						justifyContent: "space-between",
-					}}>
-					<Text
+					<View
+						style={[
+							style.separator,
+							{
+								marginHorizontal: 0,
+							},
+						]}
+					/>
+					<TouchableOpacity
+						onPress={() => navigation.navigate("WaterSelectBrand")}
 						style={{
-							color: colors.text,
-							fontSize: 16,
-							lineHeight: 24,
+							flexDirection: "row",
+							alignItems: "center",
+							justifyContent: "space-between",
 						}}>
-						订水品牌
-					</Text>
-					<View style={{flexDirection: "row", alignItems: "center"}}>
 						<Text
 							style={{
-								color: colors.fontB3,
+								color: colors.text,
 								fontSize: 16,
 								lineHeight: 24,
 							}}>
-							{waterBrandIdToName[waterBrand]}
+							订水品牌
 						</Text>
-						<IconRight height={24} width={24} />
-					</View>
-				</TouchableOpacity>
-				<View
-					style={[
-						style.separator,
-						{
-							marginHorizontal: 0,
-						},
-					]}
-				/>
-				<TouchableOpacity
-					onPress={() => navigation.navigate("WaterSelectTicketNumber", params)}
-					style={{
-						flexDirection: "row",
-						alignItems: "center",
-						justifyContent: "space-between",
-					}}>
-					<Text
+						<View style={{flexDirection: "row", alignItems: "center"}}>
+							<Text
+								style={{
+									color: colors.fontB3,
+									fontSize: 16,
+									lineHeight: 24,
+								}}>
+								{waterBrandIdToName[waterBrand]}
+							</Text>
+							<IconRight height={24} width={24} />
+						</View>
+					</TouchableOpacity>
+					<View
+						style={[
+							style.separator,
+							{
+								marginHorizontal: 0,
+							},
+						]}
+					/>
+					<TouchableOpacity
+						onPress={() => navigation.navigate("WaterSelectTicketNumber", params)}
 						style={{
-							color: colors.text,
-							fontSize: 16,
-							lineHeight: 24,
+							flexDirection: "row",
+							alignItems: "center",
+							justifyContent: "space-between",
 						}}>
-						订水票量
-					</Text>
-					<View style={{flexDirection: "row", alignItems: "center"}}>
 						<Text
 							style={{
-								color: colors.fontB3,
+								color: colors.text,
 								fontSize: 16,
 								lineHeight: 24,
 							}}>
-							{params.ticketNumber} 张
+							订水票量
 						</Text>
-						<IconRight height={24} width={24} />
-					</View>
-				</TouchableOpacity>
-			</RoundedView>
-			<View
-				style={{
-					marginTop: 40,
-					flexDirection: "row",
-					justifyContent: "flex-end",
-				}}>
-				<TouchableOpacity
-					onPress={() => {
-						Snackbar.show({
-							text: getStr("processing"),
-							duration: Snackbar.LENGTH_SHORT,
-						});
-						if (helper.mocked()) {
+						<View style={{flexDirection: "row", alignItems: "center"}}>
+							<Text
+								style={{
+									color: colors.fontB3,
+									fontSize: 16,
+									lineHeight: 24,
+								}}>
+								{params.ticketNumber} 张
+							</Text>
+							<IconRight height={24} width={24} />
+						</View>
+					</TouchableOpacity>
+				</RoundedView>
+				<View
+					style={{
+						marginTop: 40,
+						flexDirection: "row",
+						justifyContent: "flex-end",
+					}}>
+					<TouchableOpacity
+						onPress={() => {
 							Snackbar.show({
-								text: "订水成功！",
-								duration: Snackbar.LENGTH_LONG,
+								text: getStr("processing"),
+								duration: Snackbar.LENGTH_SHORT,
 							});
-						} else {
-							postWaterSubmission(
-								waterId ?? "",
-								String(waterNumber),
-								String(params.ticketNumber),
-								waterBrand ?? "6",
-								address,
-							)
-								.then(() => {
-									Snackbar.show({
-										text: "订水成功！",
-										duration: Snackbar.LENGTH_LONG,
-									});
-								})
-								.catch(NetworkRetry);
-						}
-					}}
-					disabled={submissionDisabled}
-					style={{
-						backgroundColor: submissionDisabled
-							? colors.themeGrey
-							: colors.primaryLight,
-						paddingVertical: 8,
-						paddingHorizontal: 16,
-						borderRadius: 4,
-					}}>
-					<Text style={{color: colors.contentBackground, fontSize: 20}}>
-						{getStr("submitOrder")}
+							if (helper.mocked()) {
+								Snackbar.show({
+									text: "订水成功！",
+									duration: Snackbar.LENGTH_LONG,
+								});
+							} else {
+								postWaterSubmission(
+									waterId ?? "",
+									String(waterNumber),
+									String(params.ticketNumber),
+									waterBrand ?? "6",
+									address,
+								)
+									.then(() => {
+										Snackbar.show({
+											text: "订水成功！",
+											duration: Snackbar.LENGTH_LONG,
+										});
+									})
+									.catch(NetworkRetry);
+							}
+						}}
+						disabled={submissionDisabled}
+						style={{
+							backgroundColor: submissionDisabled
+								? colors.themeGrey
+								: colors.primaryLight,
+							paddingVertical: 8,
+							paddingHorizontal: 16,
+							borderRadius: 4,
+						}}>
+						<Text style={{color: colors.contentBackground, fontSize: 20}}>
+							{getStr("submitOrder")}
+						</Text>
+					</TouchableOpacity>
+				</View>
+				<View style={{margin: 16, marginTop: 39}}>
+					<Text style={{color: colors.fontB3}}>
+						初次使用或订水票用完，请拨打商家联系电话：
+						<Text style={{textDecorationLine: "underline"}}>62781118</Text> 、
+						<Text style={{textDecorationLine: "underline"}}>62773725</Text>
 					</Text>
-				</TouchableOpacity>
-			</View>
-			<View style={{margin: 16, marginTop: 39}}>
-				<Text style={{color: colors.fontB3}}>
-					初次使用或订水票用完，请拨打商家联系电话：
-					<Text style={{textDecorationLine: "underline"}}>62781118</Text> 、
-					<Text style={{textDecorationLine: "underline"}}>62773725</Text>
-				</Text>
-				<Text />
-				<Text style={{color: colors.primaryLight}}>作者：</Text>
-				<TouchableOpacity
-					onPress={() =>
-						Linking.openURL("https://github.com/THUzxj").then(() =>
-							console.log("Opening THUzxj GitHub page in system explorer"),
-						)
-					}>
-					<Text style={{color: colors.primaryLight}}>THUzxj @ GitHub</Text>
-				</TouchableOpacity>
-				<TouchableOpacity
-					onPress={() =>
-						Linking.openURL("https://github.com/t4rf9").then(() =>
-							console.log("Opening t4rf9 GitHub page in system explorer"),
-						)
-					}>
-					<Text style={{color: colors.primaryLight}}>t4rf9 @ GitHub</Text>
-				</TouchableOpacity>
-				<Text />
-				<Text style={{color: colors.fontB3}}>
-					本功能是接入 THU Info
-					的开源第三方功能，尚未经过充分测试，如遇任何问题请随时向我们反馈。
-				</Text>
-			</View>
-		</ScrollView>
+					<Text />
+					<Text style={{color: colors.primaryLight}}>作者：</Text>
+					<TouchableOpacity
+						onPress={() =>
+							Linking.openURL("https://github.com/THUzxj").then(() =>
+								console.log("Opening THUzxj GitHub page in system explorer"),
+							)
+						}>
+						<Text style={{color: colors.primaryLight}}>THUzxj @ GitHub</Text>
+					</TouchableOpacity>
+					<TouchableOpacity
+						onPress={() =>
+							Linking.openURL("https://github.com/t4rf9").then(() =>
+								console.log("Opening t4rf9 GitHub page in system explorer"),
+							)
+						}>
+						<Text style={{color: colors.primaryLight}}>t4rf9 @ GitHub</Text>
+					</TouchableOpacity>
+					<Text />
+					<Text style={{color: colors.fontB3}}>
+						本功能是接入 THU Info
+						的开源第三方功能，尚未经过充分测试，如遇任何问题请随时向我们反馈。
+					</Text>
+				</View>
+			</ScrollView>
+		</KeyboardAvoidingScreen>
 	);
 };
 

--- a/apps/thu-info-app/src/ui/news/news.tsx
+++ b/apps/thu-info-app/src/ui/news/news.tsx
@@ -1,9 +1,9 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {ThemedRefreshControl} from "../../components/themedRefreshControl";
 import {
 	Text,
 	View,
 	Dimensions,
-	Keyboard,
 	ScrollView,
 	TextInput,
 	FlatList,
@@ -332,25 +332,9 @@ export const NewsScreen = ({navigation}: {navigation: RootNav}) => {
 
 	let screenHeight = Dimensions.get("window");
 
-	const [keyboardHeight, setKeyboardHeight] = useState(0);
-
-	useEffect(() => {
-		const keyboardDidShowListener = Keyboard.addListener("keyboardDidShow", (e) => {
-			setKeyboardHeight(e.endCoordinates.height); // Capture the keyboard height when it appears
-		});
-
-		const keyboardDidHideListener = Keyboard.addListener("keyboardDidHide", () => {
-			setKeyboardHeight(0); // Reset when the keyboard is hidden
-		});
-
-		return () => {
-			keyboardDidHideListener.remove();
-			keyboardDidShowListener.remove();
-		};
-	}, []);
-
 	return (
-		<View
+		<KeyboardAvoidingScreen
+			keyboardVerticalOffset={0}
 			style={{flex: 1, paddingTop: getStatusBarHeight()}}
 			key={darkModeHook}>
 			<View style={{flex: 0}}>
@@ -613,7 +597,7 @@ export const NewsScreen = ({navigation}: {navigation: RootNav}) => {
 			<View style={{
 				position: "absolute",
 				width: "100%",
-				bottom: keyboardHeight > 0 ? keyboardHeight - 60 : 60,
+				bottom: 0,
 				padding: 12,
 				alignItems: "flex-end",
 			}}>
@@ -660,6 +644,6 @@ export const NewsScreen = ({navigation}: {navigation: RootNav}) => {
 					</View>
 				</TouchableWithoutFeedback>
 			</View>
-		</View>
+		</KeyboardAvoidingScreen>
 	);
 };

--- a/apps/thu-info-app/src/ui/news/newsSub.tsx
+++ b/apps/thu-info-app/src/ui/news/newsSub.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {
 	ScrollView,
 	Text,
@@ -108,166 +109,168 @@ export const NewsSubScreen = ({navigation}: {navigation: RootNav}) => {
 	useEffect(fetchSubscriptionList, []);
 
 	return (
-		<ScrollView style={{backgroundColor: theme.colors.themeBackground}}>
-			<View
-				style={{
-					marginHorizontal: 12,
-				}}>
-				<Text
+		<KeyboardAvoidingScreen>
+			<ScrollView style={{backgroundColor: theme.colors.themeBackground}}>
+				<View
 					style={{
-						textAlign: "left",
-						fontSize: 15,
-						marginTop: 18,
-						marginLeft: 12,
-						marginBottom: 8,
-						fontWeight: "bold",
-						color: theme.colors.text,
+						marginHorizontal: 12,
 					}}>
-					{getStr("mySub")}
-				</Text>
-				{subList.map((s) => (
-					<NewsSubItem newsSub={s} key={s.id} setSubList={setSubList} />
-				))}
-				<Text
-					style={{
-						textAlign: "left",
-						fontSize: 15,
-						marginTop: 18,
-						marginLeft: 12,
-						marginBottom: 8,
-						fontWeight: "bold",
-						color: theme.colors.text,
-					}}>
-					{getStr("createSub")}
-				</Text>
-				<RoundedView style={{marginTop: 16, padding: 16}}>
-					<TouchableOpacity
-						onPress={() => {
-							// @ts-ignore
-							navigation.navigate("NewsSubSourceSelect", {
-								sourceSelected,
-								setSourceSelected,
-							});
-						}}>
-						<View style={{flexDirection: "row", alignItems: "center"}}>
-							<Text style={{color: theme.colors.fontB1, fontSize: 16, flex: 0}}>
-								{getStr("newsSource")}
-							</Text>
-							<View style={{flex: 1}} />
-							<Text
-								style={{color: theme.colors.fontB3, fontSize: 16, flex: 0}}
-								numberOfLines={1}>
-								{sourceSelected.sourceName}
-							</Text>
-							<IconRight height={24} width={24} />
-						</View>
-					</TouchableOpacity>
-					<View
+					<Text
 						style={{
-							height: 1,
-							backgroundColor: theme.colors.themeGrey,
-							marginVertical: 12,
-						}}
-					/>
-					<TouchableOpacity
-						onPress={() => {
-							// @ts-ignore
-							navigation.navigate("NewsSubChannelSelect", {
-								channelSelected,
-								setChannelSelected,
-							});
-						}}>
-						<View style={{flexDirection: "row", alignItems: "center"}}>
-							<Text style={{color: theme.colors.fontB1, fontSize: 16, flex: 0}}>
-								{getStr("newsChannel")}
-							</Text>
-							<View style={{flex: 1}} />
-							<Text
-								style={{color: theme.colors.fontB3, fontSize: 16, flex: 0}}
-								numberOfLines={1}>
-								{channelSelected.title}
-							</Text>
-							<IconRight height={24} width={24} />
-						</View>
-					</TouchableOpacity>
-					<View
-						style={{
-							height: 1,
-							backgroundColor: theme.colors.themeGrey,
-							marginVertical: 12,
-						}}
-					/>
-					<TextInput
-						style={{
+							textAlign: "left",
+							fontSize: 15,
+							marginTop: 18,
+							marginLeft: 12,
+							marginBottom: 8,
+							fontWeight: "bold",
 							color: theme.colors.text,
-							padding: 0,
-							fontSize: 16,
-						}}
-						placeholder={getStr("newsKeyword")}
-						placeholderTextColor={theme.colors.fontB3}
-						selectionColor={theme.colors.accent}
-						onChangeText={setKeyword}
-					/>
-				</RoundedView>
-				<Text
-					style={{
-						justifyContent: "center",
-						paddingVertical: 12,
-						paddingHorizontal: 16,
-						marginVertical: 4,
-						fontSize: 16,
-						color: theme.colors.fontB3,
-					}}>
-					{getStr("newsSubTip")}
-				</Text>
-				<View style={{flexDirection: "row", justifyContent: "flex-end"}}>
-					<TouchableOpacity
-						style={{
-							backgroundColor:
-								sourceSelected.sourceId === "" &&
-								channelSelected.id === undefined
-									? theme.colors.themeGrey
-									: theme.colors.primaryLight,
-							alignItems: "center",
-							justifyContent: "center",
-							paddingVertical: 8,
-							paddingHorizontal: 24,
-							borderRadius: 4,
-							marginRight: 12,
-						}}
-						disabled={
-							sourceSelected.sourceId === "" && channelSelected.id === undefined
-						}
-						onPress={() => {
-							helper
-								.addNewsSubscription(
-									// @ts-ignore
-									channelSelected.id,
-									sourceSelected.sourceId,
-									keyword,
-								)
-								.then((res) => {
-									if (res) {
-										setSourceSelected(emptySource);
-										setChannelSelected(emptyChannel);
-										fetchSubscriptionList();
-									} else {
-										return;
-									}
-								})
-								.catch(NetworkRetry);
 						}}>
-						<Text
-							style={{
-								color: theme.colors.contentBackground,
-								fontSize: 16,
+						{getStr("mySub")}
+					</Text>
+					{subList.map((s) => (
+						<NewsSubItem newsSub={s} key={s.id} setSubList={setSubList} />
+					))}
+					<Text
+						style={{
+							textAlign: "left",
+							fontSize: 15,
+							marginTop: 18,
+							marginLeft: 12,
+							marginBottom: 8,
+							fontWeight: "bold",
+							color: theme.colors.text,
+						}}>
+						{getStr("createSub")}
+					</Text>
+					<RoundedView style={{marginTop: 16, padding: 16}}>
+						<TouchableOpacity
+							onPress={() => {
+								// @ts-ignore
+								navigation.navigate("NewsSubSourceSelect", {
+									sourceSelected,
+									setSourceSelected,
+								});
 							}}>
-							{getStr("add")}
-						</Text>
-					</TouchableOpacity>
+							<View style={{flexDirection: "row", alignItems: "center"}}>
+								<Text style={{color: theme.colors.fontB1, fontSize: 16, flex: 0}}>
+									{getStr("newsSource")}
+								</Text>
+								<View style={{flex: 1}} />
+								<Text
+									style={{color: theme.colors.fontB3, fontSize: 16, flex: 0}}
+									numberOfLines={1}>
+									{sourceSelected.sourceName}
+								</Text>
+								<IconRight height={24} width={24} />
+							</View>
+						</TouchableOpacity>
+						<View
+							style={{
+								height: 1,
+								backgroundColor: theme.colors.themeGrey,
+								marginVertical: 12,
+							}}
+						/>
+						<TouchableOpacity
+							onPress={() => {
+								// @ts-ignore
+								navigation.navigate("NewsSubChannelSelect", {
+									channelSelected,
+									setChannelSelected,
+								});
+							}}>
+							<View style={{flexDirection: "row", alignItems: "center"}}>
+								<Text style={{color: theme.colors.fontB1, fontSize: 16, flex: 0}}>
+									{getStr("newsChannel")}
+								</Text>
+								<View style={{flex: 1}} />
+								<Text
+									style={{color: theme.colors.fontB3, fontSize: 16, flex: 0}}
+									numberOfLines={1}>
+									{channelSelected.title}
+								</Text>
+								<IconRight height={24} width={24} />
+							</View>
+						</TouchableOpacity>
+						<View
+							style={{
+								height: 1,
+								backgroundColor: theme.colors.themeGrey,
+								marginVertical: 12,
+							}}
+						/>
+						<TextInput
+							style={{
+								color: theme.colors.text,
+								padding: 0,
+								fontSize: 16,
+							}}
+							placeholder={getStr("newsKeyword")}
+							placeholderTextColor={theme.colors.fontB3}
+							selectionColor={theme.colors.accent}
+							onChangeText={setKeyword}
+						/>
+					</RoundedView>
+					<Text
+						style={{
+							justifyContent: "center",
+							paddingVertical: 12,
+							paddingHorizontal: 16,
+							marginVertical: 4,
+							fontSize: 16,
+							color: theme.colors.fontB3,
+						}}>
+						{getStr("newsSubTip")}
+					</Text>
+					<View style={{flexDirection: "row", justifyContent: "flex-end"}}>
+						<TouchableOpacity
+							style={{
+								backgroundColor:
+									sourceSelected.sourceId === "" &&
+									channelSelected.id === undefined
+										? theme.colors.themeGrey
+										: theme.colors.primaryLight,
+								alignItems: "center",
+								justifyContent: "center",
+								paddingVertical: 8,
+								paddingHorizontal: 24,
+								borderRadius: 4,
+								marginRight: 12,
+							}}
+							disabled={
+								sourceSelected.sourceId === "" && channelSelected.id === undefined
+							}
+							onPress={() => {
+								helper
+									.addNewsSubscription(
+										// @ts-ignore
+										channelSelected.id,
+										sourceSelected.sourceId,
+										keyword,
+									)
+									.then((res) => {
+										if (res) {
+											setSourceSelected(emptySource);
+											setChannelSelected(emptyChannel);
+											fetchSubscriptionList();
+										} else {
+											return;
+										}
+									})
+									.catch(NetworkRetry);
+							}}>
+							<Text
+								style={{
+									color: theme.colors.contentBackground,
+									fontSize: 16,
+								}}>
+								{getStr("add")}
+							</Text>
+						</TouchableOpacity>
+					</View>
 				</View>
-			</View>
-		</ScrollView>
+			</ScrollView>
+		</KeyboardAvoidingScreen>
 	);
 };
 

--- a/apps/thu-info-app/src/ui/settings/digitalPassword.tsx
+++ b/apps/thu-info-app/src/ui/settings/digitalPassword.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {useEffect, useState} from "react";
 import {getStr} from "../../utils/i18n";
 import {Text, useColorScheme, View} from "react-native";
@@ -74,7 +75,7 @@ export const DigitalPasswordScreen = ({
 	}, []);
 
 	return (
-		<View style={{flex: 1, padding: 12, justifyContent: "center"}}>
+		<KeyboardAvoidingScreen style={{flex: 1, padding: 12, justifyContent: "center"}}>
 			<RoundedView
 				style={{
 					width: "100%",
@@ -175,6 +176,6 @@ export const DigitalPasswordScreen = ({
 					</RoundedView>
 				</View>
 			)}
-		</View>
+		</KeyboardAvoidingScreen>
 	);
 };

--- a/apps/thu-info-app/src/ui/settings/login.tsx
+++ b/apps/thu-info-app/src/ui/settings/login.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {
 	TextInput,
 	View,
@@ -102,7 +103,7 @@ export const LoginScreen = ({navigation}: {navigation: RootNav}) => {
 	};
 
 	return (
-		<View style={style.container}>
+		<KeyboardAvoidingScreen style={style.container}>
 			<View style={style.absoluteContainer}>
 				<IconMain width={108} height={108} />
 				<View style={{height: 20}} />
@@ -182,7 +183,7 @@ export const LoginScreen = ({navigation}: {navigation: RootNav}) => {
 					<Text style={style.loggingInCaptionStyle}>{getStr("loggingIn")}</Text>
 				</View>
 			) : null}
-		</View>
+		</KeyboardAvoidingScreen>
 	);
 };
 

--- a/apps/thu-info-app/src/ui/settings/myhomeLogin.tsx
+++ b/apps/thu-info-app/src/ui/settings/myhomeLogin.tsx
@@ -1,4 +1,5 @@
-import {TextInput, View, Text, TouchableOpacity} from "react-native";
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
+import {TextInput, Text, TouchableOpacity} from "react-native";
 import {useState} from "react";
 import {useDispatch, useSelector} from "react-redux";
 import {helper, State} from "../../redux/store";
@@ -27,7 +28,7 @@ export const MyhomeLoginScreen = ({navigation}: {navigation: RootNav}) => {
 	const dispatch = useDispatch();
 
 	return (
-		<View style={style.container}>
+		<KeyboardAvoidingScreen style={style.container}>
 			<RoundedView style={style.inputRounded}>
 				<IconPerson width={18} height={18} />
 				<TextInput
@@ -90,7 +91,7 @@ export const MyhomeLoginScreen = ({navigation}: {navigation: RootNav}) => {
 					</Text>
 				</RoundedView>
 			</TouchableOpacity>
-		</View>
+		</KeyboardAvoidingScreen>
 	);
 };
 

--- a/apps/thu-info-app/src/ui/settings/resetDormPassword.tsx
+++ b/apps/thu-info-app/src/ui/settings/resetDormPassword.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {TextInput, View, Text, TouchableOpacity} from "react-native";
 import {useState} from "react";
 import {helper} from "../../redux/store";
@@ -25,7 +26,7 @@ export const ResetDormPasswordScreen = ({
 	const style = styles(themeName);
 
 	return (
-		<View style={style.container}>
+		<KeyboardAvoidingScreen style={style.container}>
 			<RoundedView style={style.inputRounded}>
 				<IconLock width={18} height={18} />
 				<TextInput
@@ -74,6 +75,6 @@ export const ResetDormPasswordScreen = ({
 					{getStr("resetDormPasswordHint")}
 				</Text>
 			</View>
-		</View>
+		</KeyboardAvoidingScreen>
 	);
 };

--- a/apps/thu-info-app/src/ui/settings/twoFactorAuth.tsx
+++ b/apps/thu-info-app/src/ui/settings/twoFactorAuth.tsx
@@ -1,3 +1,4 @@
+import {KeyboardAvoidingScreen} from "../../components/keyboardAvoidingScreen";
 import {View, Text, TouchableOpacity, Linking} from "react-native";
 import {useEffect, useState} from "react";
 import {futures, helper} from "../../redux/store";
@@ -42,7 +43,7 @@ export const TwoFactorAuthScreen = ({
 	}, []);
 
 	return (
-		<View style={{flex: 1, padding: 12}}>
+		<KeyboardAvoidingScreen style={{flex: 1, padding: 12}}>
 			<Text style={{marginLeft: 8, color: colors.fontB2, marginTop: 12}}>
 				{getStr("twoFactorPrompt")}
 			</Text>
@@ -185,6 +186,6 @@ export const TwoFactorAuthScreen = ({
 					/>
 				</RoundedView>
 			)}
-		</View>
+		</KeyboardAvoidingScreen>
 	);
 };

--- a/apps/thu-info-app/test/keyboardAvoidingScreen.test.tsx
+++ b/apps/thu-info-app/test/keyboardAvoidingScreen.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import {afterEach, expect, jest, test} from "@jest/globals";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+} from "@testing-library/react-native";
+import {HeaderHeightContext} from "@react-navigation/elements";
+import {Keyboard, Platform, StyleSheet, TextInput} from "react-native";
+import {KeyboardAvoidingScreen} from "../src/components/keyboardAvoidingScreen";
+
+const originalOS = Platform.OS;
+afterEach(async () => {
+	await cleanup();
+	jest.restoreAllMocks();
+	Platform.OS = originalOS;
+});
+
+test.each([
+	{os: "android", header: 64, offset: undefined, bottom: 300},
+	{os: "ios", header: 64, offset: undefined, bottom: 300},
+	{os: "android", header: undefined, offset: undefined, bottom: 236},
+	{os: "ios", header: undefined, offset: undefined, bottom: 236},
+	{os: "android", header: 64, offset: 0, bottom: 236},
+	{os: "ios", header: 64, offset: 0, bottom: 236},
+] as const)(
+	"$os restores layout after keyboard dismissal (header=$header, offset=$offset)",
+	async ({os, header, offset, bottom}) => {
+		Platform.OS = os;
+		const listeners = new Map<string, (event: any) => void>();
+		jest.spyOn(Keyboard, "addListener").mockImplementation((name, listener) => {
+			listeners.set(name, listener);
+			return {remove: () => listeners.delete(name)};
+		});
+		await render(
+			<HeaderHeightContext.Provider value={header}>
+				<KeyboardAvoidingScreen keyboardVerticalOffset={offset}>
+					<TextInput testID="input" />
+				</KeyboardAvoidingScreen>
+			</HeaderHeightContext.Provider>,
+		);
+		const outer = screen.root;
+		if (!outer) throw new Error("Keyboard avoidance root was not rendered");
+		await fireEvent(outer, "layout", {
+			persist: () => {},
+			nativeEvent: {layout: {x: 0, y: 0, width: 400, height: 736}},
+		});
+		for (let cycle = 0; cycle < 2; cycle++) {
+			await act(async () => {
+				listeners.get(os === "ios" ? "keyboardWillShow" : "keyboardDidShow")!({
+					duration: 0,
+					endCoordinates: {screenY: 500, height: 300, screenX: 0, width: 400},
+				});
+			});
+			const shown = StyleSheet.flatten(outer.props.style);
+			expect(os === "ios" ? shown.paddingBottom : shown.height).toBe(
+				os === "ios" ? bottom : 736 - bottom,
+			);
+			await act(async () => {
+				listeners.get(os === "ios" ? "keyboardWillHide" : "keyboardDidHide")!({
+					duration: 0,
+					endCoordinates: {screenY: 500, height: 0, screenX: 0, width: 400},
+				});
+			});
+			const hidden = StyleSheet.flatten(outer.props.style);
+			expect(hidden.flex).toBe(1);
+			expect(hidden.height).toBeUndefined();
+			if (os === "ios") expect(hidden.paddingBottom).toBe(0);
+		}
+	},
+);

--- a/apps/thu-info-app/test/serializable.test.ts
+++ b/apps/thu-info-app/test/serializable.test.ts
@@ -1,0 +1,38 @@
+import {findNonSerializableValue} from "@reduxjs/toolkit";
+import dayjs from "dayjs";
+import {expect, test} from "@jest/globals";
+import {
+	getSerializableEntries,
+	isSerializable,
+} from "../src/redux/serializable";
+
+test("accepts Dayjs schedule times but still rejects other class instances", () => {
+	const scheduleState = {
+		schedule: {
+			baseSchedule: [
+				{
+					activeTime: {
+						base: [{beginTime: dayjs("2026-09-14T09:50:00+08:00")}],
+					},
+				},
+			],
+		},
+	};
+
+	expect(
+		findNonSerializableValue(
+			scheduleState,
+			"",
+			isSerializable,
+			getSerializableEntries,
+		),
+	).toBe(false);
+	expect(
+		findNonSerializableValue(
+			{date: new Date("2026-09-14T09:50:00+08:00")},
+			"",
+			isSerializable,
+			getSerializableEntries,
+		),
+	).toEqual(expect.objectContaining({keyPath: "date"}));
+});

--- a/setup-harmony.sh
+++ b/setup-harmony.sh
@@ -2,12 +2,23 @@
 
 set -e
 
-# Reverse 09ff3a86 (snackbar v3) except lockfiles—avoids git revert merge conflicts on package.json.
-# --3way tolerates nearby edits (e.g. schedule.tsx) when plain -R fails.
-git diff 09ff3a86^..09ff3a86 -- \
-	':(exclude)apps/thu-info-app/package.json' \
-	':(exclude)yarn.lock' \
-	| git apply -R --3way
+# Harmony uses Snackbar v2's default export. Convert current sources instead of
+# reversing the v3 migration commit, whose patch conflicts with newer UI edits.
+node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const root = 'apps/thu-info-app/src';
+for (const entry of fs.readdirSync(root, {recursive: true})) {
+  if (!/\.tsx?$/.test(entry)) continue;
+  const file = path.join(root, entry);
+  const source = fs.readFileSync(file, 'utf8');
+  const converted = source.replace(
+    /import\s*\{\s*Snackbar\s*\}\s*from\s*(['"])react-native-snackbar\1/g,
+    'import Snackbar from $1react-native-snackbar$1',
+  );
+  if (converted !== source) fs.writeFileSync(file, converted);
+}
+NODE
 
 yarn workspace @thu-info/lib add cheerio@1.0.0-rc.12
 yarn workspace @thu-info/app add \


### PR DESCRIPTION
Inputs on several screens and in native modals lacked keyboard avoidance. Add a shared KeyboardAvoidingScreen with navigation-header offsets, plus explicit zero offsets for modal content and News. Cover login/PIN, forms, search, schedule editing, bottom-sheet PIN entry, and DeepSeek history search.

Restore Android height behavior on online devices while preserving its header offset and existing iOS/HarmonyOS behavior. React Native 0.87.1 contains the upstream Android keyboard-dismissal fix (react/react-native#55855). News now relies on keyboard avoidance and uses bottom: 0, removing the extra 60px gap below the DeepSeek shortcut.

Validation: workspace lint passed with three existing warnings; 28 tests passed and one existing test was skipped. Added six keyboard lifecycle cases covering Android/iOS, header offsets, standalone rendering, and modal overrides. Updated the native event-emitter mock to provide removable subscriptions. TypeScript checking remains blocked by pre-existing project errors and missing HarmonyOS dependencies. No device verification has been performed; keyboard open/close and modal layouts still need Android, iOS, and HarmonyOS testing.
